### PR TITLE
User activity mixins

### DIFF
--- a/core/frontend/src/main/scala/io/udash/Application.scala
+++ b/core/frontend/src/main/scala/io/udash/Application.scala
@@ -18,11 +18,12 @@ class Application[S <: State : ClassTag](routingRegistry: RoutingRegistry[S],
                                          rootState: S,
                                          urlChangeProvider: UrlChangeProvider = WindowUrlChangeProvider) {
   private var rootElement: Element = _
-  private lazy val viewRendered = new ViewRenderer(rootElement)
-  private lazy val routingEngine = new RoutingEngine[S](routingRegistry, viewPresenterRegistry, viewRendered, rootState)
+  private lazy val viewRenderer = new ViewRenderer(rootElement)
+  private lazy val routingEngine = new RoutingEngine[S](routingRegistry, viewPresenterRegistry, viewRenderer, rootState)
 
   /**
     * Starts the application using selected element as root.
+    *
     * @param attachElement Root element of application.
     */
   def run(attachElement: Element): Unit = {
@@ -34,6 +35,7 @@ class Application[S <: State : ClassTag](routingRegistry: RoutingRegistry[S],
 
   /**
     * Changes application routing state to the provided one.
+    *
     * @param state New application routing state,
     */
   def goTo(state: S): Unit = {
@@ -50,6 +52,7 @@ class Application[S <: State : ClassTag](routingRegistry: RoutingRegistry[S],
 
   /**
     * Register callback for routing state change.
+    *
     * @param callback Callback getting newState and oldState as arguments.
     */
   def onStateChange(callback: StateChangeEvent[S] => Unit) = {

--- a/core/frontend/src/main/scala/io/udash/core/Definitions.scala
+++ b/core/frontend/src/main/scala/io/udash/core/Definitions.scala
@@ -77,7 +77,7 @@ trait State {
   * @tparam S
   */
 trait RoutingRegistry[S <: State] {
-  def matchUrl(url: Url): S
+  def matchUrl(url: Url, previous: S): S
 
   def matchState(state: S): Url
 }

--- a/core/frontend/src/main/scala/io/udash/routing/RoutingEngine.scala
+++ b/core/frontend/src/main/scala/io/udash/routing/RoutingEngine.scala
@@ -24,7 +24,7 @@ class RoutingEngine[S <: State : ClassTag](routingRegistry: RoutingRegistry[S], 
     * @param url URL to be resolved
     */
   def handleUrl(url: Url): Unit = {
-    val newState = routingRegistry.matchUrl(url)
+    val newState = routingRegistry.matchUrl(url, current)
 
     val currentStatePath = statesMap.keys.toList
     val newStatePath = getStatePath(newState)

--- a/core/frontend/src/main/scala/io/udash/routing/UrlLogging.scala
+++ b/core/frontend/src/main/scala/io/udash/routing/UrlLogging.scala
@@ -1,0 +1,22 @@
+package io.udash.routing
+
+import io.udash._
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.scalajs.concurrent.JSExecutionContext
+import scala.util.Try
+
+/**
+  * RoutingRegistry mixin simplifying logging app navigation.
+  */
+trait UrlLogging[S <: State] extends RoutingRegistry[S] {
+
+  implicit protected val loggingEC: ExecutionContext = JSExecutionContext.queue
+  protected def log(url: String, referrer: Option[String]): Unit
+
+  abstract override def matchUrl(url: Url, previous: S): S = {
+    Future(log(url.value, Try(matchState(previous).value).toOption))
+    super.matchUrl(url, previous)
+  }
+
+}

--- a/core/frontend/src/main/scala/io/udash/routing/UrlLogging.scala
+++ b/core/frontend/src/main/scala/io/udash/routing/UrlLogging.scala
@@ -9,13 +9,14 @@ import scala.util.Try
 /**
   * RoutingRegistry mixin simplifying logging app navigation.
   */
-trait UrlLogging[S <: State] extends RoutingRegistry[S] {
+trait UrlLogging[S <: State] extends RoutingRegistry[S] with StrictLogging {
 
   implicit protected val loggingEC: ExecutionContext = JSExecutionContext.queue
   protected def log(url: String, referrer: Option[String]): Unit
 
   abstract override def matchUrl(url: Url, previous: S): S = {
     Future(log(url.value, Try(matchState(previous).value).toOption))
+      .onFailure { case t => logger.warn("Logging url change failed: {}", t.getMessage) }
     super.matchUrl(url, previous)
   }
 

--- a/core/frontend/src/main/scala/io/udash/utils/Logger.scala
+++ b/core/frontend/src/main/scala/io/udash/utils/Logger.scala
@@ -4,20 +4,34 @@ import org.scalajs.dom.Console
 
 import scala.scalajs.js.Dynamic.global
 
-/** Global JS logger. */
-object Logger {
-  private val console: Console = global.console.asInstanceOf[Console]
+trait Logger {
+  def info(message: String, params: String*): Unit
 
-  def info(message: String): Unit = console.info(message)
+  def warn(message: String, params: String*): Unit
 
-  def warn(message: String): Unit = console.warn(message)
+  def error(message: String, params: String*): Unit
 
-  def error(message: String): Unit = console.error(message)
-
-  def log(message: String): Unit = console.log(message)
+  def log(message: String, params: String*): Unit
 }
 
-/** Provides `logger` reference to [[io.udash.utils.Logger]]. */
+/**
+  * Global JS logger.
+  */
+private object ConsoleLogger extends Logger {
+  private val console: Console = global.console.asInstanceOf[Console]
+
+  def info(message: String, params: String*): Unit = console.info(message, params)
+
+  def warn(message: String, params: String*): Unit = console.warn(message, params)
+
+  def error(message: String, params: String*): Unit = console.error(message, params)
+
+  def log(message: String, params: String*): Unit = console.log(message, params)
+}
+
+/**
+  * Provides `logger` reference to [[io.udash.utils.ConsoleLogger]].
+  */
 trait StrictLogging {
-  val logger = Logger
+  val logger: Logger = ConsoleLogger
 }

--- a/core/frontend/src/test/scala/io/udash/ApplicationTest.scala
+++ b/core/frontend/src/test/scala/io/udash/ApplicationTest.scala
@@ -2,15 +2,12 @@ package io.udash
 
 import io.udash.testing._
 
-class ApplicationTest extends UdashFrontendTest {
-  import scalatags.JsDom.all._
+class ApplicationTest extends UdashFrontendTest with TestRouting {
 
   "Application" should {
+    initTestRouting()
     val initUrl = Url("/")
     val urlProvider: TestUrlChangeProvider = new TestUrlChangeProvider(initUrl)
-    val routing: TestRoutingRegistry = new TestRoutingRegistry
-    val viewPresenter: TestViewPresenter[ErrorState.type] = new TestViewPresenter[ErrorState.type]
-    val vpRegistry: TestViewPresenterRegistry = new TestViewPresenterRegistry(Map.empty, viewPresenter)
     val app = new Application[TestState](routing, vpRegistry, RootState, urlProvider)
 
     app.run(emptyComponent())

--- a/core/frontend/src/test/scala/io/udash/routing/UrlLoggingTest.scala
+++ b/core/frontend/src/test/scala/io/udash/routing/UrlLoggingTest.scala
@@ -1,0 +1,28 @@
+package io.udash.routing
+
+import io.udash._
+import io.udash.testing._
+
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.ExecutionContext
+
+class UrlLoggingTest extends UdashFrontendTest with TestRouting {
+  "UrlLogging" should {
+
+    "call logging impl on url change" in {
+      val urlWithRef = ListBuffer.empty[(String, Option[String])]
+      initTestRoutingEngine(new TestRoutingRegistry with UrlLogging[TestState] {
+
+        override implicit protected val loggingEC: ExecutionContext = testExecutionContext
+
+        override protected def log(url: String, referrer: Option[String]): Unit =
+          urlWithRef += ((url, referrer))
+      })
+
+      val urls = Seq("/", "/next", "/abc/1", "/next")
+      val expected = (urls.head, Some("")) :: urls.sliding(2).map { case Seq(prev, current) => (current, Some(prev)) }.toList
+      urls.foreach(str => routingEngine.handleUrl(Url(str)))
+      urlWithRef.toList shouldBe expected
+    }
+  }
+}

--- a/core/frontend/src/test/scala/io/udash/testing/TestRouting.scala
+++ b/core/frontend/src/test/scala/io/udash/testing/TestRouting.scala
@@ -1,0 +1,29 @@
+package io.udash.testing
+
+import io.udash._
+import io.udash.routing.RoutingEngine
+
+trait TestRouting {
+  self: UdashFrontendTest =>
+  var routing: TestRoutingRegistry = _
+  var viewPresenter: TestViewPresenter[ErrorState.type] = _
+  var vpRegistry: TestViewPresenterRegistry = _
+  var renderer: TestViewRenderer = _
+  var routingEngine: RoutingEngine[TestState] = _
+
+  protected def initTestRouting(routing: TestRoutingRegistry = new TestRoutingRegistry,
+                                state2vp: Map[TestState, ViewPresenter[_ <: TestState]] = Map.empty
+                               ): Unit = {
+    this.routing = routing
+    viewPresenter = new TestViewPresenter[ErrorState.type]
+    vpRegistry = new TestViewPresenterRegistry(state2vp, viewPresenter)
+    renderer = new TestViewRenderer
+  }
+
+  protected def initTestRoutingEngine(routing: TestRoutingRegistry = new TestRoutingRegistry,
+                                      state2vp: Map[TestState, ViewPresenter[_ <: TestState]] = Map.empty
+                                     ): Unit = {
+    initTestRouting(routing, state2vp)
+    routingEngine = new RoutingEngine[TestState](routing, vpRegistry, renderer, RootState)
+  }
+}

--- a/core/frontend/src/test/scala/io/udash/testing/TestRoutingRegistry.scala
+++ b/core/frontend/src/test/scala/io/udash/testing/TestRoutingRegistry.scala
@@ -10,7 +10,7 @@ class TestRoutingRegistry extends RoutingRegistry[TestState] {
   var urlsHistory: mutable.ArrayBuffer[Url] = mutable.ArrayBuffer.empty
   var statesHistory: mutable.ArrayBuffer[TestState] = mutable.ArrayBuffer.empty
 
-  override def matchUrl(url: Url): TestState = {
+  override def matchUrl(url: Url, previous: TestState): TestState = {
     urlsHistory.append(url)
     url.value match {
       case "/" => ObjectState

--- a/i18n/frontend/src/main/scala/io/udash/i18n/FrontendTranslationProvider.scala
+++ b/i18n/frontend/src/main/scala/io/udash/i18n/FrontendTranslationProvider.scala
@@ -1,8 +1,8 @@
 package io.udash.i18n
 
-import io.udash.utils.Logger
+import io.udash.StrictLogging
 
-trait FrontendTranslationProvider extends TranslationProvider {
+trait FrontendTranslationProvider extends TranslationProvider with StrictLogging {
   protected def handleMixedPlaceholders(template: String): Unit =
-    Logger.warn(s"""Indexed and unindexed placeholders in "$template"!""")
+    logger.warn(s"""Indexed and unindexed placeholders in "$template"!""")
 }

--- a/i18n/frontend/src/main/scala/io/udash/i18n/RemoteTranslationProvider.scala
+++ b/i18n/frontend/src/main/scala/io/udash/i18n/RemoteTranslationProvider.scala
@@ -2,16 +2,16 @@ package io.udash.i18n
 
 import java.{util => ju}
 
-import io.udash.utils.Logger
 import org.scalajs.dom.ext.Storage
 
-import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ExecutionContext, Future}
 import scala.scalajs.js
 import scala.util.Try
 
 /**
   * TranslationProvider dedicated to applications using RPC system.
+  *
   * @param translationsEndpoint RPC endpoint serving translations.
   * @param cache Optional `org.scalajs.dom.ext.Storage`, it will be used as translations cache.
   * @param ttl Time period between translations refresh, if using `cache`.
@@ -27,7 +27,7 @@ class RemoteTranslationProvider(translationsEndpoint: RemoteTranslationRPC,
 
   private var reloading: Future[Option[Bundle]] = null
 
-  if (cache.isEmpty) Logger.warn("RemoteTranslationProvider has no cache, so it will request server for every translation.")
+  if (cache.isEmpty) logger.warn("RemoteTranslationProvider has no cache, so it will request server for every translation.")
 
   def translate(key: String, argv: Any*)(implicit lang: Lang): Future[Translated] =
     fromCache(key)
@@ -44,7 +44,7 @@ class RemoteTranslationProvider(translationsEndpoint: RemoteTranslationRPC,
             case Some(translationString) =>
               Future.successful(translationString)
             case None =>
-              Logger.warn(s"Key $key not found in cache!")
+              logger.warn(s"Key $key not found in cache!")
               Future.failed(new IllegalArgumentException(s"Key $key not found in cache!"))
           }
       case None =>

--- a/i18n/frontend/src/main/scala/io/udash/i18n/bindings/AttrTranslationBinding.scala
+++ b/i18n/frontend/src/main/scala/io/udash/i18n/bindings/AttrTranslationBinding.scala
@@ -1,23 +1,21 @@
 package io.udash.i18n.bindings
 
+import io.udash.StrictLogging
 import io.udash.bindings.Bindings
 import io.udash.i18n.Translated
-import io.udash.utils.Logger
 import org.scalajs.dom
-import org.scalajs.dom._
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
-import scalatags.JsDom
 import scalatags.generic.Modifier
 
-private[i18n] class AttrTranslationBinding(translation: Future[Translated], attr: String)
-                                          (implicit ec: ExecutionContext) extends Modifier[dom.Element] with Bindings {
+private[i18n] class AttrTranslationBinding(translation: Future[Translated], attr: String)(implicit ec: ExecutionContext)
+  extends Modifier[dom.Element] with Bindings with StrictLogging {
   override def applyTo(t: dom.Element): Unit =
     translation onComplete {
       case Success(text) =>
         t.setAttribute(attr, text.string)
       case Failure(ex) =>
-        Logger.error(ex.getMessage)
+        logger.error(ex.getMessage)
     }
 }

--- a/i18n/frontend/src/main/scala/io/udash/i18n/bindings/DynamicAttrTranslationBinding.scala
+++ b/i18n/frontend/src/main/scala/io/udash/i18n/bindings/DynamicAttrTranslationBinding.scala
@@ -2,7 +2,6 @@ package io.udash.i18n.bindings
 
 import io.udash._
 import io.udash.i18n.{Lang, Translated, TranslationKey}
-import io.udash.utils.Logger
 import org.scalajs.dom
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -10,14 +9,15 @@ import scala.util.{Failure, Success}
 import scalatags.generic.Modifier
 
 private[i18n] class DynamicAttrTranslationBinding[Key <: TranslationKey](key: Key, translator: (Key) => Future[Translated], attr: String)
-                                                                        (implicit ec: ExecutionContext, lang: ReadableProperty[Lang]) extends Modifier[dom.Element] {
+                                                                        (implicit ec: ExecutionContext, lang: ReadableProperty[Lang])
+  extends Modifier[dom.Element] with StrictLogging {
   override def applyTo(t: dom.Element): Unit = {
     def rebuild(): Unit = {
       translator(key) onComplete {
         case Success(text) =>
           t.setAttribute(attr, text.string)
         case Failure(ex) =>
-          Logger.error(ex.getMessage)
+          logger.error(ex.getMessage)
       }
     }
 

--- a/i18n/frontend/src/main/scala/io/udash/i18n/bindings/DynamicTranslationBinding.scala
+++ b/i18n/frontend/src/main/scala/io/udash/i18n/bindings/DynamicTranslationBinding.scala
@@ -2,7 +2,6 @@ package io.udash.i18n.bindings
 
 import io.udash._
 import io.udash.i18n._
-import io.udash.utils.Logger
 import org.scalajs.dom
 import org.scalajs.dom._
 
@@ -12,7 +11,8 @@ import scalatags.JsDom
 import scalatags.generic.Modifier
 
 private[i18n] class DynamicTranslationBinding[Key <: TranslationKey](key: Key, translator: (Key) => Future[Translated], placeholder: Option[dom.Element])
-                                                                    (implicit ec: ExecutionContext, lang: ReadableProperty[Lang]) extends Modifier[dom.Element] {
+                                                                    (implicit ec: ExecutionContext, lang: ReadableProperty[Lang])
+  extends Modifier[dom.Element] with StrictLogging {
   override def applyTo(t: dom.Element): Unit = {
     var holder: Element = placeholder.getOrElse(emptyStringNode())
     t.appendChild(holder)
@@ -27,7 +27,7 @@ private[i18n] class DynamicTranslationBinding[Key <: TranslationKey](key: Key, t
           )
           holder = newHolder
         case Failure(ex) =>
-          Logger.error(ex.getMessage)
+          logger.error(ex.getMessage)
       }
     }
 

--- a/i18n/frontend/src/main/scala/io/udash/i18n/bindings/TranslationBinding.scala
+++ b/i18n/frontend/src/main/scala/io/udash/i18n/bindings/TranslationBinding.scala
@@ -1,8 +1,8 @@
 package io.udash.i18n.bindings
 
+import io.udash.StrictLogging
 import io.udash.bindings.Bindings
 import io.udash.i18n.Translated
-import io.udash.utils.Logger
 import org.scalajs.dom
 import org.scalajs.dom._
 
@@ -12,7 +12,8 @@ import scalatags.JsDom
 import scalatags.generic.Modifier
 
 private[i18n] class TranslationBinding(translation: Future[Translated], placeholder: Option[dom.Element])
-                                      (implicit ec: ExecutionContext) extends Modifier[dom.Element] with Bindings {
+                                      (implicit ec: ExecutionContext)
+  extends Modifier[dom.Element] with Bindings with StrictLogging {
   override def applyTo(t: dom.Element): Unit = {
     val holder: Element = placeholder.getOrElse(emptyStringNode())
     t.appendChild(holder)
@@ -24,7 +25,7 @@ private[i18n] class TranslationBinding(translation: Future[Translated], placehol
           holder
         )
       case Failure(ex) =>
-        Logger.error(ex.getMessage)
+        logger.error(ex.getMessage)
     }
   }
 }

--- a/rpc/backend/src/main/scala/io/udash/rpc/utils/CallLogging.scala
+++ b/rpc/backend/src/main/scala/io/udash/rpc/utils/CallLogging.scala
@@ -1,0 +1,32 @@
+package io.udash.rpc.utils
+
+import com.avsystem.commons.rpc.RPCMetadata
+import io.udash.rpc.ExposesServerRPC
+
+import scala.concurrent.Future
+
+/**
+  * ExposesServerRPC mixin simplifying RPC calls logging.
+  */
+trait CallLogging[ServerRPCType] extends ExposesServerRPC[ServerRPCType] {
+
+  protected val metadata: RPCMetadata[ServerRPCType]
+
+  def log(rpcName: String, methodName: String, args: Seq[String]): Unit
+
+  override def handleRpcCall(call: framework.RPCCall): Future[framework.RawValue] = {
+    val classMetadata = call
+      .gettersChain.reverse
+      .foldLeft[RPCMetadata[_]](metadata)((metadata, invocation) => metadata.getterResultMetadata(invocation.rpcName))
+
+    classMetadata
+      .methodsByRpcName
+      .get(call.invocation.rpcName)
+      .filter(_.signature.annotations.exists(_.isInstanceOf[Logged]))
+      .foreach(methodMetadata =>
+        log(classMetadata.name, methodMetadata.signature.methodName, call.invocation.argLists.flatMap(_.map(framework.rawToString)))
+      )
+    super.handleRpcCall(call)
+  }
+
+}

--- a/rpc/backend/src/test/scala/io/udash/rpc/internals/ExposesServerRPCTest.scala
+++ b/rpc/backend/src/test/scala/io/udash/rpc/internals/ExposesServerRPCTest.scala
@@ -1,9 +1,12 @@
 package io.udash.rpc.internals
 
+import com.avsystem.commons.rpc.RPCMetadata
 import io.udash.rpc._
+import io.udash.rpc.utils.CallLogging
 import io.udash.testing.UdashBackendTest
 
 import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
 
 class ExposesServerRPCTest extends UdashBackendTest {
 
@@ -83,8 +86,7 @@ class ExposesServerRPCTest extends UdashBackendTest {
     val impl = TestRPC.rpcImpl((method: String, args: List[List[Any]], result: Option[Any]) => {
       calls += method
     })
-    val rpc = new DefaultExposesServerRPC[TestRPC](impl)
-    rpc
+    new DefaultExposesServerRPC[TestRPC](impl)
   }
 
   final class UPickleExposesServerRPC[ServerRPCType]
@@ -98,10 +100,35 @@ class ExposesServerRPCTest extends UdashBackendTest {
     val impl = TestRPC.rpcImpl((method: String, args: List[List[Any]], result: Option[Any]) => {
       calls += method
     })
-    val rpc = new UPickleExposesServerRPC[TestRPC](impl)
-    rpc
+    new UPickleExposesServerRPC[TestRPC](impl)
+  }
+
+  val loggedCalls = ListBuffer.empty[String]
+
+  def createLoggingRpc(calls: mutable.Builder[String, Seq[String]]): ExposesServerRPC[TestRPC] = {
+    val impl = TestRPC.rpcImpl((method: String, args: List[List[Any]], result: Option[Any]) => {
+      calls += method
+    })
+    new ExposesServerRPC[TestRPC](impl) with CallLogging[TestRPC] {
+      override protected val metadata: RPCMetadata[TestRPC] = RPCMetadata[TestRPC]
+
+      override val framework = DefaultUdashRPCFramework
+
+      import framework._
+
+      override protected def localRpcAsRaw: framework.AsRawRPC[TestRPC] = framework.AsRawRPC[TestRPC]
+
+      override def log(rpcName: String, methodName: String, args: Seq[String]): Unit = loggedCalls += s"$rpcName $methodName $args"
+    }
   }
 
   "DefaultExposesServerRPC" should tests(createDefaultRpc)
   "CustomExposesServerRPC" should tests(createCustomRpc)
+  "LoggingExposesServerRPC" should {
+    tests(createLoggingRpc)
+    import io.udash.rpc.InnerRPC
+    "log calls of annotated RPC methods" in {
+      loggedCalls.toList shouldBe List(s"${classOf[InnerRPC].getSimpleName} func List(5)")
+    }
+  }
 }

--- a/rpc/frontend/src/main/scala/io/udash/rpc/internals/ServerConnector.scala
+++ b/rpc/frontend/src/main/scala/io/udash/rpc/internals/ServerConnector.scala
@@ -1,7 +1,7 @@
 package io.udash.rpc.internals
 
+import io.udash.StrictLogging
 import io.udash.rpc.{DefaultUdashRPCFramework, UdashRPCFramework}
-import io.udash.utils.Logger
 import io.udash.wrappers.atmosphere._
 
 import scala.collection.mutable
@@ -13,12 +13,13 @@ trait ServerConnector[RPCRequest] {
 }
 
 /** [[io.udash.rpc.internals.ServerConnector]] implementation based on Atmosphere framework. */
-abstract class AtmosphereServerConnector[RPCRequest](private val serverUrl: String) extends ServerConnector[RPCRequest] {
+abstract class AtmosphereServerConnector[RPCRequest](private val serverUrl: String)
+  extends ServerConnector[RPCRequest] with StrictLogging {
   protected val clientRpc: ExposesClientRPC[_]
 
   val rpcFramework: UdashRPCFramework
 
-  import rpcFramework.{RPCResponse, RPCFire, read, stringToRaw, RPCResponseCodec, RPCRequestCodec}
+  import rpcFramework.{RPCFire, RPCResponse, read, stringToRaw}
 
   def requestToString(request: RPCRequest): String
 
@@ -78,11 +79,11 @@ abstract class AtmosphereServerConnector[RPCRequest](private val serverUrl: Stri
             case fire: RPCFire =>
               handleRpcFire(fire)
             case unhandled =>
-              Logger.error(s"Unhandled RPCRequest: $unhandled")
+              logger.error(s"Unhandled RPCRequest: $unhandled")
           }
         } catch {
           case _: Exception =>
-            Logger.error(s"Unhandled message: $msg")
+            logger.error(s"Unhandled message: $msg")
         }
     }
   }

--- a/rpc/shared/shared/src/main/scala/io/udash/rpc/utils/Logged.scala
+++ b/rpc/shared/shared/src/main/scala/io/udash/rpc/utils/Logged.scala
@@ -1,0 +1,8 @@
+package io.udash.rpc.utils
+
+import com.avsystem.commons.rpc.MetadataAnnotation
+
+/**
+  * Marks RPC method for CallLogging
+  */
+class Logged extends MetadataAnnotation

--- a/rpc/shared/shared/src/test/scala/io/udash/rpc/TestRPC.scala
+++ b/rpc/shared/shared/src/test/scala/io/udash/rpc/TestRPC.scala
@@ -2,6 +2,7 @@ package io.udash.rpc
 
 import com.avsystem.commons.rpc.{RPC, RPCName}
 import com.github.ghik.silencer.silent
+import io.udash.rpc.utils.Logged
 
 import scala.concurrent.Future
 
@@ -29,6 +30,7 @@ trait RPCMethods {
 trait InnerRPC {
   def proc(): Unit
 
+  @Logged
   def func(arg: Int): Future[String]
 }
 


### PR DESCRIPTION
Additional mixins for tracking:
* app navigation
* endpoint calls

The only _breaking_ change is in `RoutingRegistry` (previous state passed on matching URLs). but it might prove useful in other use cases as well.