### PR TITLE
Frontend UrlLogging changes

### DIFF
--- a/core/frontend/src/main/scala/io/udash/core/Definitions.scala
+++ b/core/frontend/src/main/scala/io/udash/core/Definitions.scala
@@ -77,7 +77,7 @@ trait State {
   * @tparam S
   */
 trait RoutingRegistry[S <: State] {
-  def matchUrl(url: Url, previous: S): S
+  def matchUrl(url: Url): S
 
   def matchState(state: S): Url
 }

--- a/core/frontend/src/main/scala/io/udash/routing/RoutingEngine.scala
+++ b/core/frontend/src/main/scala/io/udash/routing/RoutingEngine.scala
@@ -24,7 +24,7 @@ class RoutingEngine[S <: State : ClassTag](routingRegistry: RoutingRegistry[S], 
     * @param url URL to be resolved
     */
   def handleUrl(url: Url): Unit = {
-    val newState = routingRegistry.matchUrl(url, current)
+    val newState = routingRegistry.matchUrl(url)
 
     val currentStatePath = statesMap.keys.toList
     val newStatePath = getStatePath(newState)
@@ -61,7 +61,7 @@ class RoutingEngine[S <: State : ClassTag](routingRegistry: RoutingRegistry[S], 
 
     val oldState = current
     current = newState
-    callbacks.foreach(_.apply(StateChangeEvent(newState, oldState)))
+    if (newState != oldState) callbacks.foreach(_.apply(StateChangeEvent(newState, oldState)))
   }
 
   /**

--- a/core/frontend/src/main/scala/io/udash/view/ViewRenderer.scala
+++ b/core/frontend/src/main/scala/io/udash/view/ViewRenderer.scala
@@ -10,8 +10,8 @@ import scala.scalajs.js.timers.RawTimers
 /**
   * ViewRenderer is used to provide mechanism to render nested [[View]] within provided [[rootElement]].
   */
-private[udash] class ViewRenderer(rootElement: Element) {
-  private val endpoint = rootElement
+private[udash] class ViewRenderer(rootElement: => Element) {
+  private lazy val endpoint = rootElement
   private val views = mutable.ArrayBuffer[View]()
 
   private def mergeViews(path: List[View]): View = {

--- a/core/frontend/src/test/scala/io/udash/routing/UrlLoggingTest.scala
+++ b/core/frontend/src/test/scala/io/udash/routing/UrlLoggingTest.scala
@@ -1,6 +1,7 @@
 package io.udash.routing
 
 import io.udash._
+import io.udash.core.Url
 import io.udash.testing._
 
 import scala.collection.mutable.ListBuffer
@@ -11,17 +12,20 @@ class UrlLoggingTest extends UdashFrontendTest with TestRouting {
 
     "call logging impl on url change" in {
       val urlWithRef = ListBuffer.empty[(String, Option[String])]
-      initTestRoutingEngine(new TestRoutingRegistry with UrlLogging[TestState] {
-
+      initTestRouting()
+      val initUrl = Url("/")
+      val urlProvider: TestUrlChangeProvider = new TestUrlChangeProvider(initUrl)
+      val app = new Application[TestState](routing, vpRegistry, RootState, urlProvider) with UrlLogging[TestState] {
         override implicit protected val loggingEC: ExecutionContext = testExecutionContext
-
-        override protected def log(url: String, referrer: Option[String]): Unit =
+        override protected def log(url: String, referrer: Option[String]): Unit = {
           urlWithRef += ((url, referrer))
-      })
+        }
+      }
+      app.run(emptyComponent())
 
       val urls = Seq("/", "/next", "/abc/1", "/next")
       val expected = (urls.head, Some("")) :: urls.sliding(2).map { case Seq(prev, current) => (current, Some(prev)) }.toList
-      urls.foreach(str => routingEngine.handleUrl(Url(str)))
+      urls.foreach(str => app.goTo(routing.matchUrl(Url(str))))
       urlWithRef.toList shouldBe expected
     }
   }

--- a/core/frontend/src/test/scala/io/udash/testing/TestRoutingRegistry.scala
+++ b/core/frontend/src/test/scala/io/udash/testing/TestRoutingRegistry.scala
@@ -10,7 +10,7 @@ class TestRoutingRegistry extends RoutingRegistry[TestState] {
   var urlsHistory: mutable.ArrayBuffer[Url] = mutable.ArrayBuffer.empty
   var statesHistory: mutable.ArrayBuffer[TestState] = mutable.ArrayBuffer.empty
 
-  override def matchUrl(url: Url, previous: TestState): TestState = {
+  override def matchUrl(url: Url): TestState = {
     urlsHistory.append(url)
     url.value match {
       case "/" => ObjectState


### PR DESCRIPTION
What do you think about such change of  `UrlLogging`? I think it's better because `matchUrl` method should be responsible only for matching `Url` to `State` and it does not need previous state for this. 