### PR TITLE
Fixed problem with sending integer as value of Double from client to server.

### DIFF
--- a/rpc/shared/js/src/test/scala/io/udash/rpc/JSSerializationIntegrationTest.scala
+++ b/rpc/shared/js/src/test/scala/io/udash/rpc/JSSerializationIntegrationTest.scala
@@ -4,6 +4,7 @@ import scala.language.higherKinds
 
 class JSSerializationIntegrationTest extends SerializationIntegrationTestBase {
   override val repeats = 3
+  "DefaultUdashRPCFramework -> DefaultUdashRPCFramework default serialization" should tests(DefaultUdashRPCFramework, DefaultUdashRPCFramework)
   "DefaultUdashRPCFramework -> UPickleUdashRPCFramework default serialization" should tests(DefaultUdashRPCFramework, UPickleUdashRPCFramework)
   "UPickleUdashRPCFramework -> DefaultUdashRPCFramework  default serialization" should tests(UPickleUdashRPCFramework, DefaultUdashRPCFramework)
 }

--- a/rpc/shared/jvm/src/main/scala/io/udash/rpc/serialization/JsonInput.scala
+++ b/rpc/shared/jvm/src/main/scala/io/udash/rpc/serialization/JsonInput.scala
@@ -27,6 +27,7 @@ class JsonInput(value: JValue) extends Input {
 
   def readDouble() = _read("Double") {
     case JDouble(v) => ReadSuccessful(v)
+    case JInt(v) => ReadSuccessful(v.toDouble)
   }
 
   def readBoolean() = _read("Boolean") {

--- a/rpc/shared/jvm/src/main/scala/io/udash/rpc/serialization/jawn/JawnFacade.scala
+++ b/rpc/shared/jvm/src/main/scala/io/udash/rpc/serialization/jawn/JawnFacade.scala
@@ -16,7 +16,7 @@ object JawnFacade extends SimpleFacade[JValue] {
         JDouble(s.toDouble)
     }
 
-  override def jint(s: String) = JInt(Integer.parseInt(s))
+  override def jint(s: String) = JInt(s.toInt)
 
   override def jstring(s: String) = JString(s)
 

--- a/rpc/shared/jvm/src/test/scala/io/udash/rpc/JVMSerializationIntegrationTest.scala
+++ b/rpc/shared/jvm/src/test/scala/io/udash/rpc/JVMSerializationIntegrationTest.scala
@@ -3,6 +3,7 @@ package io.udash.rpc
 import scala.language.higherKinds
 
 class JVMSerializationIntegrationTest extends SerializationIntegrationTestBase {
+  "DefaultUdashRPCFramework -> DefaultUdashRPCFramework default serialization" should tests(DefaultUdashRPCFramework, DefaultUdashRPCFramework)
   "DefaultUdashRPCFramework -> UPickleUdashRPCFramework default serialization" should tests(DefaultUdashRPCFramework, UPickleUdashRPCFramework)
   "UPickleUdashRPCFramework -> DefaultUdashRPCFramework default serialization" should tests(UPickleUdashRPCFramework, DefaultUdashRPCFramework)
 }

--- a/rpc/shared/shared/src/test/scala/io/udash/rpc/RpcMessagesTest.scala
+++ b/rpc/shared/shared/src/test/scala/io/udash/rpc/RpcMessagesTest.scala
@@ -75,7 +75,7 @@ trait RpcMessagesTestScenarios extends UdashSharedTest with Utils {
     }
 
     "serialize and deserialize simple case classes" in {
-      val test: TestCC = TestCC(5, 123L, true, "bla", 'a' :: 'b' :: Nil)
+      val test: TestCC = TestCC(5, 123L, 432, true, "bla", 'a' :: 'b' :: Nil)
       val serialized = RPC.write[TestCC](test)
       val deserialized = RPC.read[TestCC](serialized)
 
@@ -83,8 +83,8 @@ trait RpcMessagesTestScenarios extends UdashSharedTest with Utils {
     }
 
     "serialize and deserialize nested case classes" in {
-      val test: TestCC = TestCC(5, 123L, true, "bla", 'a' :: 'b' :: Nil)
-      val test2: TestCC = TestCC(-35, 1L, true, "blsddf sdg  \"{,}[,]\"a", 'a' :: 'b' :: Nil)
+      val test: TestCC = TestCC(5, 123L, 432, true, "bla", 'a' :: 'b' :: Nil)
+      val test2: TestCC = TestCC(-35, 1L, 432, true, "blsddf sdg  \"{,}[,]\"a", 'a' :: 'b' :: Nil)
       val nested: NestedTestCC = NestedTestCC(-123, test, test2)
       val serialized = RPC.write(nested)
       val deserialized = RPC.read[NestedTestCC](serialized)
@@ -159,7 +159,7 @@ trait RpcMessagesTestScenarios extends UdashSharedTest with Utils {
 
   def hugeTests(RPC: UdashRPCFramework) = {
     "serialize and deserialize huge case classes" in {
-      def cc() = TestCC(Random.nextInt(), Random.nextLong(), Random.nextBoolean(), Random.nextString(Random.nextInt(300)), List.fill(Random.nextInt(300))('a'))
+      def cc() = TestCC(Random.nextInt(), Random.nextLong(), Random.nextInt(), Random.nextBoolean(), Random.nextString(Random.nextInt(300)), List.fill(Random.nextInt(300))('a'))
       def ncc() = NestedTestCC(Random.nextInt(), cc(), cc())
       def dncc(counter: Int = 0): DeepNestedTestCC =
         if (counter < 500) DeepNestedTestCC(ncc(), dncc(counter + 1))

--- a/rpc/shared/shared/src/test/scala/io/udash/rpc/SerializationIntegrationTestBase.scala
+++ b/rpc/shared/shared/src/test/scala/io/udash/rpc/SerializationIntegrationTestBase.scala
@@ -11,7 +11,7 @@ class SerializationIntegrationTestBase extends UdashSharedTest with Utils {
   def tests(writer: UdashRPCFramework, reader: UdashRPCFramework) = {
     "serialize and deserialize all types" in {
       for (i <- 1 to repeats) {
-        def cc() = TestCC(Random.nextInt(), Random.nextLong(), Random.nextBoolean(), Random.nextString(200), List.fill(Random.nextInt(200))('a'))
+        def cc() = TestCC(Random.nextInt(), Random.nextLong(), 123, Random.nextBoolean(), Random.nextString(200), List.fill(Random.nextInt(200))('a'))
         def ncc() = NestedTestCC(Random.nextInt(), cc(), cc())
         def dncc(counter: Int = 0): DeepNestedTestCC =
           if (counter < 200) DeepNestedTestCC(ncc(), dncc(counter + 1))

--- a/rpc/shared/shared/src/test/scala/io/udash/rpc/Utils.scala
+++ b/rpc/shared/shared/src/test/scala/io/udash/rpc/Utils.scala
@@ -20,7 +20,7 @@ trait Utils {
     binary = Array.fill(Random.nextInt(20))(Random.nextInt().toByte),
     list = List.fill(Random.nextInt(20))(Random.nextString(Random.nextInt(20))),
     set = List.fill(Random.nextInt(20))(Random.nextString(Random.nextInt(20))).toSet,
-    obj = TestCC(Random.nextInt(), Random.nextLong(), Random.nextBoolean(), Random.nextString(Random.nextInt(20)), Nil),
+    obj = TestCC(Random.nextInt(), Random.nextLong(), Random.nextInt(), Random.nextBoolean(), Random.nextString(Random.nextInt(20)), Nil),
     map = Map(Seq.fill(Random.nextInt(20))(Random.nextString(20) -> Random.nextInt()):_*)
   )
 

--- a/rpc/shared/shared/src/test/scala/io/udash/rpc/types.scala
+++ b/rpc/shared/shared/src/test/scala/io/udash/rpc/types.scala
@@ -1,6 +1,6 @@
 package io.udash.rpc
 
-case class TestCC(i: Int, l: Long, b: Boolean, s: String, list: List[Char])
+case class TestCC(i: Int, l: Long, intAsDouble: Double, b: Boolean, s: String, list: List[Char])
 case class NestedTestCC(i: Int, t: TestCC, t2: TestCC)
 case class DeepNestedTestCC(n: NestedTestCC, l: DeepNestedTestCC)
 


### PR DESCRIPTION
### Problem

RPC interface has method like:
```scala
def doSth(d: Double): Unit
````

Client calls:
```scala
serverRPC.doSth(123)
```

Result: 
Server cannot deserialize JSON, because it expects double.

@ddworak - take a look, please.