### PR TITLE
Make default RPCs non-final

### DIFF
--- a/rpc/backend/src/main/scala/io/udash/rpc/ExposesServerRPC.scala
+++ b/rpc/backend/src/main/scala/io/udash/rpc/ExposesServerRPC.scala
@@ -27,7 +27,7 @@ abstract class ExposesServerRPC[ServerRPCType](local: ServerRPCType) extends Exp
   }
 }
 
-final class DefaultExposesServerRPC[ServerRPCType]
+class DefaultExposesServerRPC[ServerRPCType]
   (local: ServerRPCType)(implicit protected val localRpcAsRaw: DefaultUdashRPCFramework.AsRawRPC[ServerRPCType])
   extends ExposesServerRPC(local) {
 

--- a/rpc/backend/src/test/scala/io/udash/rpc/internals/ExposesServerRPCTest.scala
+++ b/rpc/backend/src/test/scala/io/udash/rpc/internals/ExposesServerRPCTest.scala
@@ -109,14 +109,9 @@ class ExposesServerRPCTest extends UdashBackendTest {
     val impl = TestRPC.rpcImpl((method: String, args: List[List[Any]], result: Option[Any]) => {
       calls += method
     })
-    new ExposesServerRPC[TestRPC](impl) with CallLogging[TestRPC] {
+    new DefaultExposesServerRPC[TestRPC](impl) with CallLogging[TestRPC] {
+
       override protected val metadata: RPCMetadata[TestRPC] = RPCMetadata[TestRPC]
-
-      override val framework = DefaultUdashRPCFramework
-
-      import framework._
-
-      override protected def localRpcAsRaw: framework.AsRawRPC[TestRPC] = framework.AsRawRPC[TestRPC]
 
       override def log(rpcName: String, methodName: String, args: Seq[String]): Unit = loggedCalls += s"$rpcName $methodName $args"
     }

--- a/rpc/frontend/src/main/scala/io/udash/rpc/internals/ExposesClientRPC.scala
+++ b/rpc/frontend/src/main/scala/io/udash/rpc/internals/ExposesClientRPC.scala
@@ -26,7 +26,7 @@ abstract class ExposesClientRPC[ClientRPCType](protected val localRpc: ClientRPC
     JSExecutionContext.queue
 }
 
-final class DefaultExposesClientRPC[ClientRPCType]
+class DefaultExposesClientRPC[ClientRPCType]
   (local: ClientRPCType)(implicit protected val localRpcAsRaw: DefaultUdashRPCFramework.AsRawClientRPC[ClientRPCType])
   extends ExposesClientRPC(local) {
 


### PR DESCRIPTION
This will simplify `CallLogging` usage and enable custom user modifications.