### PR TITLE
Remove excess sequence type change

### DIFF
--- a/core/frontend/src/main/scala/io/udash/properties/Validator.scala
+++ b/core/frontend/src/main/scala/io/udash/properties/Validator.scala
@@ -43,7 +43,7 @@ object Validator {
         case Seq(Invalid(errors), tl@_*) => reduce(acc ++ errors, tl)
       }
 
-      future.map(s => reduce(Nil, s.toList))
+      future.map(s => reduce(Nil, s))
     }
   }
 }


### PR DESCRIPTION
I've forgotten to remove excess `.toList` call on the sequence when refactoring validation result fold