### PR TITLE
Libs upgrade

### DIFF
--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/statics.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/statics.scala
@@ -6,18 +6,18 @@ object BootstrapTags {
 
   import scalatags.JsDom.all._
 
-  val dataBackdrop = "data-backdrop".attr
-  val dataBind = "data-bind".attr
-  val dataDismiss = "data-dismiss".attr
-  val dataKeyboard = "data-keyboard".attr
-  val dataLabel = "data-label".attr
-  val dataParent = "data-parent".attr
-  val dataRide = "data-ride".attr
-  val dataShow = "data-show".attr
-  val dataSlide = "data-slide".attr
-  val dataSlideTo = "data-slide-to".attr
-  val dataTarget = "data-target".attr
-  val dataToggle = "data-toggle".attr
+  val dataBackdrop = attr("data-backdrop")
+  val dataBind = attr("data-bind")
+  val dataDismiss = attr("data-dismiss")
+  val dataKeyboard = attr("data-keyboard")
+  val dataLabel = attr("data-label")
+  val dataParent = attr("data-parent")
+  val dataRide = attr("data-ride")
+  val dataShow = attr("data-show")
+  val dataSlide = attr("data-slide")
+  val dataSlideTo = attr("data-slide-to")
+  val dataTarget = attr("data-target")
+  val dataToggle = attr("data-toggle")
 
 }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,13 +8,13 @@ object Dependencies extends Build {
   val jqueryWrapperVersion = "1.0.0"
 
   val scalaJsDomVersion = "0.9.1"
-  val scalaTagsVersion = "0.5.5"
+  val scalaTagsVersion = "0.6.0"
 
   val servletVersion = "3.1.0"
-  val avsCommonsVersion = "1.16.1"
+  val avsCommonsVersion = "1.16.2"
 
   val atmoshereJSVersion = "2.3.0"
-  val atmoshereVersion = "2.4.4"
+  val atmoshereVersion = "2.4.5"
 
   val upickleVersion = "0.4.1"
   val jawnParserVersion = "0.8.4"
@@ -25,7 +25,7 @@ object Dependencies extends Build {
 
   val scalatestVersion = "3.0.0-M15"
   val scalamockVersion = "3.2.2"
-  val bootstrapVersion = "3.3.6"
+  val bootstrapVersion = "3.3.7"
 
   val compilerPlugins = Def.setting(Seq(
     "com.github.ghik" % "silencer-plugin" % silencerVersion

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 logLevel := Level.Warn
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.10")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.11")
 
 libraryDependencies += "org.scala-js" %% "scalajs-env-selenium" % "0.1.3"


### PR DESCRIPTION
Scala.js: 0.6.10 -> 0.6.11
scalatags: 0.5.5 -> 0.6.0
AVS Commons: 1.16.1 -> 1.16.2
Atmosphere: 2.4.4 -> 2.4.5
Bootstrap: 3.3.6 -> 3.3.7