### PR TITLE
Rename: transform(A -> Seq[B]) to transformToSeq(A -> Seq[B])

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,27 @@
-sudo: true
+sudo: required
+dist: trusty
 language: scala
 
 scala:
   - 2.11.8
 
+jdk:
+  - oraclejdk8
+
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
   - sleep 3 # give xvfb some time to start
+  # Instal google-chrome
+  - export CHROME_BIN=/usr/bin/google-chrome
+  - sudo apt-get update
+  - sudo apt-get install -y libappindicator1 fonts-liberation
+  - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+  - sudo dpkg -i google-chrome*.deb
+  # Install Selenium chromedriver
+  - wget http://chromedriver.storage.googleapis.com/2.21/chromedriver_linux64.zip
+  - unzip chromedriver_linux64.zip -d selenium-bin
+  - export PATH=$PWD/selenium-bin:$PATH
 
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION test
-
-addons:
-  firefox: latest
+  - sbt ++$TRAVIS_SCALA_VERSION 'set (jsTestEnv in ThisBuild := new org.scalajs.jsenv.selenium.SeleniumJSEnv(org.scalajs.jsenv.selenium.Chrome))' test

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import UdashBuild._
+
 name := "udash"
 
 version in ThisBuild := "0.4.0-SNAPSHOT"
@@ -17,6 +19,8 @@ scalacOptions in ThisBuild ++= Seq(
   "-Xlint:_,-missing-interpolator,-adapted-args"
 )
 
+jsTestEnv in ThisBuild := new org.scalajs.jsenv.selenium.SeleniumJSEnv(org.scalajs.jsenv.selenium.Firefox)
+
 val commonSettings = Seq(
   moduleName := "udash-" + moduleName.value,
   libraryDependencies ++= compilerPlugins.value,
@@ -30,7 +34,7 @@ val commonJSSettings = Seq(
   scalaJSUseRhino in Test := false,
   scalaJSStage in Test := FastOptStage,
   jsDependencies in Test += RuntimeDOM % Test,
-  jsEnv in Test := new org.scalajs.jsenv.selenium.SeleniumJSEnv(org.scalajs.jsenv.selenium.Firefox),
+  jsEnv in Test := jsTestEnv.value,
   scalacOptions += {
     val localDir = (baseDirectory in ThisBuild).value.toURI.toString
     val githubDir = "https://raw.githubusercontent.com/UdashFramework/udash-core"

--- a/core/frontend/src/main/scala/io/udash/properties/single/ForwarderProperty.scala
+++ b/core/frontend/src/main/scala/io/udash/properties/single/ForwarderProperty.scala
@@ -1,15 +1,18 @@
 package io.udash.properties.single
 import java.util.UUID
 
-import io.udash.properties.PropertyCreator
+import io.udash.properties.{PropertyCreator, ValidationResult}
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 trait ForwarderReadableProperty[A] extends ReadableProperty[A] {
   protected def origin: ReadableProperty[_]
 
   override val id: UUID = PropertyCreator.newID()
   override protected[properties] def parent: ReadableProperty[_] = null
+
+  override def isValid: Future[ValidationResult] =
+    origin.isValid
 
   override def validate(): Unit =
     origin.validate()

--- a/core/frontend/src/main/scala/io/udash/properties/single/Property.scala
+++ b/core/frontend/src/main/scala/io/udash/properties/single/Property.scala
@@ -99,7 +99,7 @@ trait ReadableProperty[A] {
     * @tparam B Type of elements in new SeqProperty.
     * @return New ReadableSeqProperty[B], which will be synchronised with original ReadableProperty[A].
     */
-  def transform[B : ModelValue](transformer: A => Seq[B]): ReadableSeqProperty[B, ReadableProperty[B]] =
+  def transformToSeq[B : ModelValue](transformer: A => Seq[B]): ReadableSeqProperty[B, ReadableProperty[B]] =
     new ReadableSeqPropertyFromSingleValue(this, transformer)
 
   protected[properties] def parent: ReadableProperty[_]
@@ -171,7 +171,7 @@ trait Property[A] extends ReadableProperty[A] {
     * @tparam B Type of elements in new SeqProperty.
     * @return New ReadableSeqProperty[B], which will be synchronised with original Property[A].
     */
-  def transform[B : ModelValue](transformer: A => Seq[B], revert: Seq[B] => A): SeqProperty[B, Property[B]] =
+  def transformToSeq[B : ModelValue](transformer: A => Seq[B], revert: Seq[B] => A): SeqProperty[B, Property[B]] =
     new SeqPropertyFromSingleValue(this, transformer, revert)
 }
 

--- a/core/frontend/src/test/scala/io/udash/properties/PropertyTest.scala
+++ b/core/frontend/src/test/scala/io/udash/properties/PropertyTest.scala
@@ -227,7 +227,7 @@ class PropertyTest extends UdashFrontendTest {
         props.foreach(_.listen(_ => elementsUpdated += 1))
 
       val p = Property("1,2,3,4,5")
-      val s: ReadableSeqProperty[Int, ReadableProperty[Int]] = p.transform((v: String) => Try(v.split(",").map(_.toInt).toSeq).getOrElse(Seq[Int]()))
+      val s: ReadableSeqProperty[Int, ReadableProperty[Int]] = p.transformToSeq((v: String) => Try(v.split(",").map(_.toInt).toSeq).getOrElse(Seq[Int]()))
 
       registerElementListener(s.elemProperties)
 
@@ -352,7 +352,7 @@ class PropertyTest extends UdashFrontendTest {
 
     "not allow children modification after transformation into ReadableSeqProperty" in {
       val p = Property("1,2,3,4,5")
-      val s: ReadableSeqProperty[Int, ReadableProperty[Int]] = p.transform((v: String) => Try(v.split(",").map(_.toInt).toSeq).getOrElse(Seq[Int]()))
+      val s: ReadableSeqProperty[Int, ReadableProperty[Int]] = p.transformToSeq((v: String) => Try(v.split(",").map(_.toInt).toSeq).getOrElse(Seq[Int]()))
 
       s.elemProperties.foreach {
         case p: Property[Int] => p.set(20)
@@ -368,7 +368,7 @@ class PropertyTest extends UdashFrontendTest {
         props.foreach(_.listen(_ => elementsUpdated += 1))
 
       val p = Property("1,2,3,4,5")
-      val s: SeqProperty[Int, Property[Int]] = p.transform(
+      val s: SeqProperty[Int, Property[Int]] = p.transformToSeq(
         (v: String) => Try(v.split(",").map(_.toInt).toSeq).getOrElse(Seq[Int]()),
         (s: Seq[Int]) => s.mkString(",")
       )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Dependencies extends Build {
 
   val scalaLoggingVersion = "3.4.0"
 
-  val scalatestVersion = "3.0.0-RC4"
+  val scalatestVersion = "3.0.0"
   val bootstrapVersion = "3.3.7"
 
   val compilerPlugins = Def.setting(Seq(

--- a/project/UdashBuild.scala
+++ b/project/UdashBuild.scala
@@ -5,4 +5,6 @@ object UdashBuild extends Build {
 
   val publishedJS = taskKey[Attributed[File]]("JS file that gets packaged into JAR")
   val publishedJSDependencies = taskKey[File]("JS dependencies file that gets packaged into JAR")
+
+  val jsTestEnv = settingKey[org.scalajs.jsenv.JSEnv]("Global JS tests env.")
 }


### PR DESCRIPTION
The same name for
```scala
def transform[B](transformer: A => B): ReadableProperty[B]
```
and 
```scala
 def transform[B : ModelValue](transformer: A => Seq[B]): ReadableSeqProperty[B, ReadableProperty[B]]
```
introduced problems with inline lambdas. 