### PR TITLE
Updated to scala-commons 1.17.0 (breaking GenCodec changes)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies extends Build {
   val scalaTagsVersion = "0.6.0"
 
   val servletVersion = "3.1.0"
-  val avsCommonsVersion = "1.16.3"
+  val avsCommonsVersion = "1.17.0"
 
   val atmosphereJSVersion = "2.3.0"
   val atmosphereVersion = "2.4.5"

--- a/rpc/shared/js/src/main/scala/io/udash/rpc/serialization/NativeJsonInput.scala
+++ b/rpc/shared/js/src/main/scala/io/udash/rpc/serialization/NativeJsonInput.scala
@@ -1,39 +1,51 @@
 package io.udash.rpc.serialization
 
+import com.avsystem.commons.serialization.GenCodec.ReadFailure
 import com.avsystem.commons.serialization._
-import scalajs.js
+
+import scala.scalajs.js
 
 class NativeJsonInput(value: Any) extends Input { self =>
-  private def read[T](expected: String)(matcher: PartialFunction[Any, ValueRead[T]]): ValueRead[T] =
-    if (matcher.isDefinedAt(value)) matcher(value)
-    else ReadFailed(s"$expected expected.")
+  private def read[T](expected: String)(matcher: PartialFunction[Any, T]): T =
+    matcher.applyOrElse(value, (_: Any) => throw new ReadFailure(s"$expected expected."))
 
-  override def readNull(): ValueRead[Null] =
+  def inputType = value match {
+    case null => InputType.Null
+    case _: js.Array[_] => InputType.List
+    case _: js.Object => InputType.Object
+    case _ => InputType.Simple
+  }
+
+  override def readNull(): Null =
     read("Null") {
-      case null => ReadSuccessful(null)
+      case null => null
     }
 
-  override def readString(): ValueRead[String] =
+  override def readString(): String =
     read("String") {
-      case s: String => ReadSuccessful(s)
+      case s: String => s
     }
 
-  override def readDouble(): ValueRead[Double] =
+  override def readDouble(): Double =
     read("Double") {
-      case v: Double => ReadSuccessful(v)
+      case v: Double => v
     }
 
-  override def readInt(): ValueRead[Int] =
+  override def readInt(): Int =
     read("Int") {
-      case v: Int => ReadSuccessful(v.toInt)
+      case v: Int => v.toInt
     }
 
-  override def readLong(): ValueRead[Long] = {
+  override def readLong(): Long = {
     def parseLong(): Option[Long] = {
       value match {
         case s: String =>
-          try { Some(s.toLong) }
-          catch { case ex: NumberFormatException => None }
+          try {
+            Some(s.toLong)
+          }
+          catch {
+            case ex: NumberFormatException => None
+          }
         case i: Int => Some(i)
         case d: Double if d == d.toLong => Some(d.toLong)
         case _ => None
@@ -41,30 +53,30 @@ class NativeJsonInput(value: Any) extends Input { self =>
     }
 
     parseLong() match {
-      case Some(l) => ReadSuccessful(l)
-      case None => ReadFailed(s"Long expected.")
+      case Some(l) => l
+      case None => throw new ReadFailure(s"Long expected.")
     }
   }
 
-  override def readBoolean(): ValueRead[Boolean] =
+  override def readBoolean(): Boolean =
     read("Boolean") {
-      case v: Boolean => ReadSuccessful(v)
+      case v: Boolean => v
     }
 
-  override def readList(): ValueRead[ListInput] =
+  override def readList(): ListInput =
     read("List") {
-      case array: js.Array[_] => ReadSuccessful(new JsonListInput(array))
+      case array: js.Array[_] => new JsonListInput(array)
     }
 
-  override def readObject(): ValueRead[ObjectInput] =
+  override def readObject(): ObjectInput =
     read("Object") {
-      case obj: js.Object => ReadSuccessful(new JsonObjectInput(obj.asInstanceOf[js.Dictionary[_]]))
+      case obj: js.Object => new JsonObjectInput(obj.asInstanceOf[js.Dictionary[_]])
     }
 
   override def skip(): Unit = ()
 
-  override def readBinary(): ValueRead[Array[Byte]] = {
-    readList().map(l => l.iterator(i => i.readInt().get.toByte).toArray)
+  override def readBinary(): Array[Byte] = {
+    readList().iterator(i => i.readInt().toByte).toArray
   }
 
   class JsonListInput(list: js.Array[_]) extends ListInput {
@@ -86,9 +98,11 @@ class NativeJsonInput(value: Any) extends Input { self =>
     override def hasNext: Boolean =
       it.hasNext
 
-    override def nextField(): (String, Input) = {
+    override def nextField(): FieldInput = {
       val key = it.next()
-      (key, new NativeJsonInput(dict.apply(key)))
+      new NativeJsonFieldInput(key, dict.apply(key))
     }
   }
 }
+
+class NativeJsonFieldInput(val fieldName: String, value: Any) extends NativeJsonInput(value) with FieldInput

--- a/rpc/shared/shared/src/main/scala/io/udash/rpc/UdashRPCFramework.scala
+++ b/rpc/shared/shared/src/main/scala/io/udash/rpc/UdashRPCFramework.scala
@@ -1,6 +1,6 @@
 package io.udash.rpc
 
-import com.avsystem.commons.rpc.{GetterRPCFramework, ProcedureRPCFramework, RPCFramework}
+import com.avsystem.commons.rpc.{GetterRPCFramework, ProcedureRPCFramework}
 import com.avsystem.commons.serialization._
 
 import scala.language.postfixOps
@@ -42,15 +42,16 @@ trait UdashRPCFramework extends GetterRPCFramework with ProcedureRPCFramework wi
   /* GenCodecs for internal classes of RPC framework. */
   implicit val RawInvocationCodec = new GenCodec[RawInvocation] {
     override def read(input: Input): RawInvocation = {
-      val obj = input.readObject().get
+      val obj = input.readObject()
       var rpcName: String = null
       var args: List[List[RawValue]] = null
       while (obj.hasNext) {
-        obj.nextField() match {
-          case ("rpcName", in) =>
-            rpcName = in.readString().get
-          case ("argLists", in) =>
-            args = readArgs(in.readList().get)
+        val fi = obj.nextField()
+        fi.fieldName match {
+          case "rpcName" =>
+            rpcName = fi.readString()
+          case "argLists" =>
+            args = readArgs(fi.readList())
         }
       }
       RawInvocation(rpcName, args)
@@ -70,7 +71,7 @@ trait UdashRPCFramework extends GetterRPCFramework with ProcedureRPCFramework wi
       while (input.hasNext) {
         val i = input.nextElement()
         val argList = List.newBuilder[RawValue]
-        val it = i.readList().get.iterator((el: Input) => argList += RawValueCodec.read(el))
+        val it = i.readList().iterator((el: Input) => argList += RawValueCodec.read(el))
         while (it.hasNext) it.next()
         argLists += argList.result()
       }
@@ -88,22 +89,23 @@ trait UdashRPCFramework extends GetterRPCFramework with ProcedureRPCFramework wi
 
   implicit val RPCRequestCodec = new GenCodec[RPCRequest] {
     override def read(input: Input): RPCRequest = {
-      val obj = input.readObject().get
+      val obj = input.readObject()
       var inv: RawInvocation = null
       val getters = List.newBuilder[RawInvocation]
       var callId: String = null
       var tpe: String = null
       while (obj.hasNext) {
-        obj.nextField() match {
-          case ("inv", in) =>
-            inv = RawInvocationCodec.read(in)
-          case ("getters", in) =>
-            val l = in.readList().get
+        val fi = obj.nextField()
+        fi.fieldName match {
+          case "inv" =>
+            inv = RawInvocationCodec.read(fi)
+          case "getters" =>
+            val l = fi.readList()
             while (l.hasNext) getters += RawInvocationCodec.read(l.nextElement)
-          case ("callId", in) =>
-            callId = in.readString().get
-          case ("type", in) =>
-            tpe = in.readString().get
+          case "callId" =>
+            callId = fi.readString()
+          case "type" =>
+            tpe = fi.readString()
         }
       }
 
@@ -138,24 +140,25 @@ trait UdashRPCFramework extends GetterRPCFramework with ProcedureRPCFramework wi
 
   implicit val RPCResponseCodec = new GenCodec[RPCResponse] {
     override def read(input: Input): RPCResponse = {
-      val obj = input.readObject().get
+      val obj = input.readObject()
       var response: Any = null
       var callId: String = null
       var cause: String = null
       var errorMsg: String = null
       var tpe: String = null
       while (obj.hasNext) {
-        obj.nextField() match {
-          case ("response", in) =>
-            response = RawValueCodec.read(in)
-          case ("callId", in) =>
-            callId = in.readString().get
-          case ("cause", in) =>
-            cause = in.readString().get
-          case ("errorMsg", in) =>
-            errorMsg = in.readString().get
-          case ("type", in) =>
-            tpe = in.readString().get
+        val fi = obj.nextField()
+        fi.fieldName match {
+          case "response" =>
+            response = RawValueCodec.read(fi)
+          case "callId" =>
+            callId = fi.readString()
+          case "cause" =>
+            cause = fi.readString()
+          case "errorMsg" =>
+            errorMsg = fi.readString()
+          case "type" =>
+            tpe = fi.readString()
         }
       }
 
@@ -186,15 +189,16 @@ trait UdashRPCFramework extends GetterRPCFramework with ProcedureRPCFramework wi
 
   implicit val RPCFailureCodec = new GenCodec[RPCFailure] {
     override def read(input: Input): RPCFailure = {
-      val obj = input.readObject().get
+      val obj = input.readObject()
       var remoteCause: String = null
       var remoteMessage: String = null
       while (obj.hasNext) {
-        obj.nextField() match {
-          case ("remoteCause", in) =>
-            remoteCause = in.readString().get
-          case ("remoteMessage", in) =>
-            remoteMessage = in.readString().get
+        val fi = obj.nextField()
+        fi.fieldName match {
+          case "remoteCause" =>
+            remoteCause = fi.readString()
+          case "remoteMessage" =>
+            remoteMessage = fi.readString()
         }
       }
       RPCFailure(remoteCause, remoteMessage)

--- a/rpc/shared/shared/src/test/scala/io/udash/rpc/RpcMessagesTest.scala
+++ b/rpc/shared/shared/src/test/scala/io/udash/rpc/RpcMessagesTest.scala
@@ -152,9 +152,9 @@ trait RpcMessagesTestScenarios extends UdashSharedTest with Utils {
       case class TwoItems(i1: CompleteItem, i2: CompleteItem)
       implicit val skippingCodec = new GenCodec[TwoItems] {
         override def read(input: Input): TwoItems = {
-          val obj = input.readObject().get
-          obj.nextField()._2.skip()
-          val i2 = GenCodec.read[CompleteItem](obj.nextField()._2)
+          val obj = input.readObject()
+          obj.nextField().skip()
+          val i2 = GenCodec.read[CompleteItem](obj.nextField())
           TwoItems(null, i2)
         }
 

--- a/rpc/shared/shared/src/test/scala/io/udash/rpc/SerializationIntegrationTestBase.scala
+++ b/rpc/shared/shared/src/test/scala/io/udash/rpc/SerializationIntegrationTestBase.scala
@@ -1,6 +1,6 @@
 package io.udash.rpc
 
-import com.avsystem.commons.serialization.{GenCodec, Input, Output}
+import com.avsystem.commons.serialization.{GenCodec, Input, InputType, Output}
 import io.udash.testing.UdashSharedTest
 
 import scala.language.higherKinds
@@ -35,9 +35,13 @@ class SerializationIntegrationTestBase extends UdashSharedTest with Utils {
               case None => output.writeNull()
             }
 
-          override def read(input: Input): Option[T] =
-            if (input.readNull().isSuccess) None
-            else Some(implicitly[GenCodec[T]].read(input))
+          override def read(input: Input): Option[T] = input.inputType match {
+            case InputType.Null =>
+              input.readNull()
+              None
+            case _ =>
+              Some(implicitly[GenCodec[T]].read(input))
+          }
         }
 
       val testOpts = Seq(


### PR DESCRIPTION
The `Input` trait has [changed](https://github.com/AVSystem/scala-commons/commit/f055b7026cf3422a057d9c9e9a75a5e2f5b4d817) in `scala-commons` 1.17.0 in a backwards-incompatible way.