### PR TITLE
Add .empty in Property companions

### DIFF
--- a/core/frontend/src/main/scala/io/udash/properties/model/ModelProperty.scala
+++ b/core/frontend/src/main/scala/io/udash/properties/model/ModelProperty.scala
@@ -1,7 +1,5 @@
 package io.udash.properties.model
 
-import java.util.UUID
-
 import io.udash.properties._
 import io.udash.properties.seq.{ReadableSeqProperty, SeqProperty}
 import io.udash.properties.single.{CastableProperty, CastableReadableProperty, Property, ReadableProperty}
@@ -10,12 +8,16 @@ import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}
 
 object ModelProperty {
-  /** Creates empty ModelProperty[T]. */
-  def apply[T](implicit pc: PropertyCreator[T], ev: ModelPart[T], ec: ExecutionContext): ModelProperty[T] =
-    Property[T].asModel
+  /** Creates an empty ModelProperty[T]. */
+  def empty[T: PropertyCreator : ModelPart](implicit ec: ExecutionContext): ModelProperty[T] =
+    Property.empty[T].asModel
+
+  /** Creates an empty ModelProperty[T]. */
+  def apply[T: PropertyCreator : ModelPart](implicit ec: ExecutionContext): ModelProperty[T] =
+    empty
 
   /** Creates ModelProperty[T] with initial value. */
-  def apply[T](init: T)(implicit pc: PropertyCreator[T], ev: ModelPart[T], ec: ExecutionContext): ModelProperty[T] =
+  def apply[T: PropertyCreator : ModelPart](init: T)(implicit ec: ExecutionContext): ModelProperty[T] =
     Property[T](init).asModel
 }
 

--- a/core/frontend/src/main/scala/io/udash/properties/seq/SeqProperty.scala
+++ b/core/frontend/src/main/scala/io/udash/properties/seq/SeqProperty.scala
@@ -12,11 +12,15 @@ import scala.concurrent.{ExecutionContext, Future}
 object SeqProperty {
   /** Creates an empty DirectSeqProperty[T]. */
   def empty[T](implicit pc: PropertyCreator[Seq[T]], ev: ModelSeq[Seq[T]], ec: ExecutionContext): SeqProperty[T, CastableProperty[T]] =
-    Property[Seq[T]].asSeq[T]
+    Property.empty[Seq[T]].asSeq[T]
+
+  /** Creates an empty DirectSeqProperty[T]. */
+  def apply[T](implicit pc: PropertyCreator[Seq[T]], ev: ModelSeq[Seq[T]], ec: ExecutionContext): SeqProperty[T, CastableProperty[T]] =
+    empty
 
   /** Creates a DirectSeqProperty[T] with initial value. */
   def apply[T](item: T, more: T*)(implicit pc: PropertyCreator[Seq[T]], ev: ModelSeq[Seq[T]], ec: ExecutionContext): SeqProperty[T, CastableProperty[T]] =
-    Property[Seq[T]](item +: more).asSeq[T]
+    apply(item +: more)
 
   /** Creates a DirectSeqProperty[T] with initial value. */
   def apply[T](init: Seq[T])(implicit pc: PropertyCreator[Seq[T]], ev: ModelSeq[Seq[T]], ec: ExecutionContext): SeqProperty[T, CastableProperty[T]] =

--- a/core/frontend/src/main/scala/io/udash/properties/seq/SeqProperty.scala
+++ b/core/frontend/src/main/scala/io/udash/properties/seq/SeqProperty.scala
@@ -10,15 +10,15 @@ import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}
 
 object SeqProperty {
-  /** Creates empty DirectSeqProperty[T]. */
-  def apply[T](implicit pc: PropertyCreator[Seq[T]], ev: ModelSeq[Seq[T]], ec: ExecutionContext): SeqProperty[T, CastableProperty[T]] =
+  /** Creates an empty DirectSeqProperty[T]. */
+  def empty[T](implicit pc: PropertyCreator[Seq[T]], ev: ModelSeq[Seq[T]], ec: ExecutionContext): SeqProperty[T, CastableProperty[T]] =
     Property[Seq[T]].asSeq[T]
 
-  /** Creates DirectSeqProperty[T] with initial value. */
+  /** Creates a DirectSeqProperty[T] with initial value. */
   def apply[T](item: T, more: T*)(implicit pc: PropertyCreator[Seq[T]], ev: ModelSeq[Seq[T]], ec: ExecutionContext): SeqProperty[T, CastableProperty[T]] =
     Property[Seq[T]](item +: more).asSeq[T]
 
-  /** Creates DirectSeqProperty[T] with initial value. */
+  /** Creates a DirectSeqProperty[T] with initial value. */
   def apply[T](init: Seq[T])(implicit pc: PropertyCreator[Seq[T]], ev: ModelSeq[Seq[T]], ec: ExecutionContext): SeqProperty[T, CastableProperty[T]] =
     Property[Seq[T]](init).asSeq[T]
 }
@@ -56,7 +56,7 @@ trait ReadableSeqProperty[A, +ElemType <: ReadableProperty[A]] extends ReadableP
     new FilteredSeqProperty[A, ElemType](this, matcher)
 
   /** Combines every element of this `SeqProperty` with provided `Property` creating new `ReadableSeqProperty` as the result. */
-  def combine[B, O : ModelValue](property: ReadableProperty[B])(combiner: (A, B) => O): ReadableSeqProperty[O, ReadableProperty[O]] = {
+  def combine[B, O: ModelValue](property: ReadableProperty[B])(combiner: (A, B) => O): ReadableSeqProperty[O, ReadableProperty[O]] = {
     class CombinedReadableSeqProperty(s: ReadableSeqProperty[A, _ <: ReadableProperty[A]],
                                       p: ReadableProperty[B], override val executionContext: ExecutionContext)
       extends ReadableSeqProperty[O, ReadableProperty[O]] {
@@ -100,15 +100,15 @@ trait ReadableSeqProperty[A, +ElemType <: ReadableProperty[A]] extends ReadableP
   }
 
   /** Zips elements from `this` and provided `property` by combining every pair using provided `combiner`. */
-  def zip[B, O : ModelValue](property: ReadableSeqProperty[B, ReadableProperty[B]])(combiner: (A, B) => O): ReadableSeqProperty[O, ReadableProperty[O]] =
+  def zip[B, O: ModelValue](property: ReadableSeqProperty[B, ReadableProperty[B]])(combiner: (A, B) => O): ReadableSeqProperty[O, ReadableProperty[O]] =
     new ZippedReadableSeqProperty(this, property, combiner, executionContext)
 
   /** Zips elements from `this` and provided `property` by combining every pair using provided `combiner`.
     * Uses `defaultA` and `defaultB` to fill smaller sequence. */
-  def zipAll[B, O : ModelValue](property: ReadableSeqProperty[B, ReadableProperty[B]])
-                               (combiner: (A, B) => O,
-                                defaultA: ReadableProperty[A],
-                                defaultB: ReadableProperty[B]): ReadableSeqProperty[O, ReadableProperty[O]] =
+  def zipAll[B, O: ModelValue](property: ReadableSeqProperty[B, ReadableProperty[B]])
+                              (combiner: (A, B) => O,
+                               defaultA: ReadableProperty[A],
+                               defaultB: ReadableProperty[B]): ReadableSeqProperty[O, ReadableProperty[O]] =
     new ZippedAllReadableSeqProperty(this, property, combiner, defaultA, defaultB, executionContext)
 
   /** Zips elements from `this` SeqProperty with their indexes. */

--- a/core/frontend/src/main/scala/io/udash/properties/single/Property.scala
+++ b/core/frontend/src/main/scala/io/udash/properties/single/Property.scala
@@ -12,12 +12,16 @@ import scala.language.higherKinds
 import scala.util.{Failure, Success}
 
 object Property {
-  /** Creates empty DirectProperty[T]. */
-  def apply[T](implicit pc: PropertyCreator[T], ec: ExecutionContext): CastableProperty[T] =
+  /** Creates an empty DirectProperty[T]. */
+  def empty[T](implicit pc: PropertyCreator[T], ec: ExecutionContext): CastableProperty[T] =
     pc.newProperty(null)
 
+  /** Creates an empty DirectProperty[T]. */
+  def apply[T: PropertyCreator](implicit ec: ExecutionContext): CastableProperty[T] =
+    empty
+
   /** Creates DirectProperty[T] with initial value. */
-  def apply[T](init: T)(implicit pc: PropertyCreator[T], ec: ExecutionContext): CastableProperty[T]=
+  def apply[T](init: T)(implicit pc: PropertyCreator[T], ec: ExecutionContext): CastableProperty[T] =
     pc.newProperty(init, null)
 }
 
@@ -26,7 +30,7 @@ trait ReadableProperty[A] {
   protected[this] val listeners: mutable.Set[A => Any] = mutable.Set()
 
   protected[this] val validators: mutable.Set[Validator[A]] = mutable.Set()
-  protected[this] var validationResult: Future[ValidationResult] = null
+  protected[this] var validationResult: Future[ValidationResult] = _
 
   implicit protected[properties] def executionContext: ExecutionContext
 


### PR DESCRIPTION
The empty case `.apply` in `SeqProperty` had to be used explicitly anyway, so it's better for it to have a correct name, consistent with the collections API.