### PR TITLE
Current state property

### DIFF
--- a/core/frontend/src/main/scala/io/udash/Application.scala
+++ b/core/frontend/src/main/scala/io/udash/Application.scala
@@ -1,5 +1,6 @@
 package io.udash
 
+import io.udash.properties.ImmutableValue
 import io.udash.routing.{StateChangeEvent, WindowUrlChangeProvider}
 import org.scalajs.dom.Element
 
@@ -13,10 +14,10 @@ import scala.reflect.ClassTag
   * @param rootState The instance of [[io.udash.core.State]] which will treated as main state.
   * @tparam S Should be a sealed trait which extends [[io.udash.core.State]].
   */
-class Application[S <: State : ClassTag](routingRegistry: RoutingRegistry[S],
-                                         viewPresenterRegistry: ViewPresenterRegistry[S],
-                                         rootState: S,
-                                         urlChangeProvider: UrlChangeProvider = WindowUrlChangeProvider) {
+class Application[S <: State : ClassTag : ImmutableValue](routingRegistry: RoutingRegistry[S],
+                                                          viewPresenterRegistry: ViewPresenterRegistry[S],
+                                                          rootState: S,
+                                                          urlChangeProvider: UrlChangeProvider = WindowUrlChangeProvider) {
   private var rootElement: Element = _
   private lazy val viewRenderer = new ViewRenderer(rootElement)
   private lazy val routingEngine = new RoutingEngine[S](routingRegistry, viewPresenterRegistry, viewRenderer, rootState)
@@ -55,7 +56,7 @@ class Application[S <: State : ClassTag](routingRegistry: RoutingRegistry[S],
     *
     * @param callback Callback getting newState and oldState as arguments.
     */
-  def onStateChange(callback: StateChangeEvent[S] => Unit) = {
+  def onStateChange(callback: StateChangeEvent[S] => Unit): Registration = {
     routingEngine.onStateChange(callback)
   }
 
@@ -66,4 +67,8 @@ class Application[S <: State : ClassTag](routingRegistry: RoutingRegistry[S],
 
   /** Current application routing state. */
   def currentState: S = routingEngine.currentState
+
+  /** @return Property reflecting current routing state */
+  def currentStateProperty: ReadableProperty[S] = routingEngine.currentStateProperty
+
 }

--- a/core/frontend/src/test/scala/io/udash/routing/RoutingEngineTest.scala
+++ b/core/frontend/src/test/scala/io/udash/routing/RoutingEngineTest.scala
@@ -3,8 +3,6 @@ package io.udash.routing
 import io.udash._
 import io.udash.testing._
 
-import scala.collection.mutable.ListBuffer
-
 class RoutingEngineTest extends UdashFrontendTest with TestRouting {
 
   "RoutingEngine" should {


### PR DESCRIPTION
While reviewing our production code, I encountered a recurring pattern - state being copied to a `Property` in order to bind component changes to the state change. I believe we should expose it using our best supported mechanism and avoid such duplication. I also used this opportunity to rewrite handling URLs for more verbose (and hopefully performant) mutability.