### PR TITLE
Properties improvements

### DIFF
--- a/core/frontend/src/test/scala/io/udash/properties/PropertyCreatorTest.scala
+++ b/core/frontend/src/test/scala/io/udash/properties/PropertyCreatorTest.scala
@@ -148,6 +148,26 @@ class PropertyCreatorTest extends UdashFrontendTest {
       """trait T {
         |  def i: Int
         |  def s: String
+        |  var x: Int = 5
+        |}
+        |trait T2 {
+        |  def t: T
+        |}
+        |val p = Property[T2].asModel""".stripMargin shouldNot compile
+
+      """trait T {
+        |  def i: Int
+        |  def s: String
+        |  var x: Int = 5
+        |}
+        |trait T2 {
+        |  val t: T
+        |}
+        |val p = Property[T2].asModel""".stripMargin shouldNot compile
+
+      """trait T {
+        |  def i: Int
+        |  def s: String
         |  val x: Int = 5
         |}
         |val p = Property[T].asModel

--- a/core/frontend/src/test/scala/io/udash/properties/PropertyTest.scala
+++ b/core/frontend/src/test/scala/io/udash/properties/PropertyTest.scala
@@ -802,6 +802,54 @@ class PropertyTest extends UdashFrontendTest {
       c.get.a should be(-10)
       c.get.b should be(-5)
     }
+
+    "handle trait with implemented defs and vals" in {
+      trait ModelWithImplDef {
+        def x: Int
+        def y: Int = 5
+      }
+      trait ModelWithImplVal {
+        val x: Int
+        val y: Int = 5
+      }
+
+      val p1 = ModelProperty[ModelWithImplDef]
+      val p2 = ModelProperty[ModelWithImplVal]
+
+      p1.subProp(_.x).set(12)
+      p1.subProp(_.x).get should be(12)
+      p1.get.x should be(12)
+      p1.get.y should be(5)
+
+      p2.subProp(_.x).set(12)
+      p2.subProp(_.x).get should be(12)
+      p2.get.x should be(12)
+      p2.get.y should be(5)
+    }
+
+    "handle case class with implemented defs and vals" in {
+      trait Utils {
+        val userLabel: String = "User:"
+      }
+      case class User(login: String, name: Option[String]) extends Utils {
+        val displayName: String = name.getOrElse(login)
+
+        def withLabel: String =
+          s"$userLabel $displayName"
+      }
+
+      val p = ModelProperty[User](User("udash", Some("Udash Framework")))
+      p.get.withLabel should be("User: Udash Framework")
+
+      p.subProp(_.name).set(None)
+      p.get.withLabel should be("User: udash")
+
+      p.subProp(_.login).set("tester")
+      p.get.withLabel should be("User: tester")
+
+      p.subProp(_.name).set(Some("Test Test"))
+      p.get.withLabel should be("User: Test Test")
+    }
   }
 
   "SeqProperty" should {

--- a/core/frontend/src/test/scala/manual/PropertyErrorManualTest.scala
+++ b/core/frontend/src/test/scala/manual/PropertyErrorManualTest.scala
@@ -12,15 +12,19 @@ object PropertyErrorManualTest {
 
   /**
     * Expected error:
+    *
     * `manual.PropertyErrorManualTest.ClassicClass` should meet requirements for one of:
     *   * model value - it has to be an immutable value (io.udash.properties.ImmutableValue[manual.PropertyErrorManualTest.ClassicClass] has to exist), model part or model seq
-    *   * model part - it has to be a trait with abstract methods returning valid model values or a simple case class (contains only vals with valid model values in the primary constructor)
+    *   * model part - it has to be a trait with abstract methods returning valid model values or an immutable case class
     *   * model seq - it has to be Seq[T] where T is a valid model value
     *
     * Try to call one of these methods in your code to get more details:
+    *   * ImmutableValue.isImmutable[manual.PropertyErrorManualTest.ClassicClass]
     *   * ModelValue.isModelValue[manual.PropertyErrorManualTest.ClassicClass]
     *   * ModelPart.isModelPart[manual.PropertyErrorManualTest.ClassicClass]
     *   * ModelSeq.isModelSeq[manual.PropertyErrorManualTest.ClassicClass]
+    *
+    *     val classicClassProperty = Property[ClassicClass]
     */
 //  object GeneralPropertyError {
 //    val classicClassProperty = Property[ClassicClass]
@@ -43,7 +47,7 @@ object PropertyErrorManualTest {
 
   /**
     * Expected error:
-    * The type `manual.PropertyErrorManualTest.ClassicClass` does not meet model part requirements. It must be (not sealed) trait or simple case class.
+    * The type `manual.PropertyErrorManualTest.ClassicClass` does not meet model part requirements. It must be (not sealed) trait or immutable case class.
     *
     * Model part checks:
     * * for traits:
@@ -51,7 +55,7 @@ object PropertyErrorManualTest {
     *   * isNotSealedTrait: true
     *   * isNotSeq: true
     *   * members: Visible only for traits.
-    * * for simple case class:
+    * * for case class:
     *   * isCaseClass: false
     *   * members: Visible only for case classes.
     *
@@ -91,10 +95,11 @@ object PropertyErrorManualTest {
     * Expected error:
     * `manual.PropertyErrorManualTest.A` should meet requirements for one of:
     *   * model value - it has to be an immutable value (io.udash.properties.ImmutableValue[manual.PropertyErrorManualTest.A] has to exist), model part or model seq
-    *   * model part - it has to be a trait with abstract methods returning valid model values or a simple case class (contains only vals with valid model values in the primary constructor)
+    *   * model part - it has to be a trait with abstract methods returning valid model values or an immutable case class
     *   * model seq - it has to be Seq[T] where T is a valid model value
     *
     * Try to call one of these methods in your code to get more details:
+    *   * ImmutableValue.isImmutable[manual.PropertyErrorManualTest.A]
     *   * ModelValue.isModelValue[manual.PropertyErrorManualTest.A]
     *   * ModelPart.isModelPart[manual.PropertyErrorManualTest.A]
     *   * ModelSeq.isModelSeq[manual.PropertyErrorManualTest.A]
@@ -205,5 +210,46 @@ object PropertyErrorManualTest {
 //    ImmutableValue.isImmutable[CCA]
 //    ImmutableValue.isImmutable[CCB]
 //    ImmutableValue.isImmutable[CCD]
+//  }
+
+  trait PathTestA {
+    def s: String
+    def b: PathTestB
+
+    def test2: PathTestB = null
+  }
+
+  trait PathTestB {
+    def s: String
+    def a: PathTestA
+
+    def test: String = "asd"
+  }
+
+  /**
+    * The path must consist of ModelParts and only leaf can be ImmutableValue or ModelSeq.
+    *  * test is NOT a valid subproperty (unimplemented def for trait based model or constructor element for case class based model)
+    *  * String is an immutable value (check ImmutableValue.isImmutable[String])
+    *  * String is NOT a ModelPart (check ModelPart.isModelPart[String])
+    *  * String is NOT a ModelSeq (check ModelSeq.isModelSeq[String])
+    *
+    *     p.subProp(_.b.a.b.test)
+    */
+//  object PathTestError {
+//    val p = ModelProperty.empty[PathTestA]
+//    p.subProp(_.b.a.b.test)
+//  }
+
+
+  /**
+    * The path must consist of ModelParts and only leaf can be ImmutableValue or ModelSeq.
+    *  * test2 is NOT a valid subproperty (unimplemented def for trait based model or constructor element for case class based model)
+    *  * manual.PropertyErrorManualTest.PathTestB is a ModelPart (check ModelPart.isModelPart[manual.PropertyErrorManualTest.PathTestB])
+    *
+    *     p.subProp(_.b.a.test2.a.b.a.s)
+    */
+//  object PathTestError2 {
+//    val p = ModelProperty.empty[PathTestA]
+//    p.subProp(_.b.a.test2.a.b.a.s)
 //  }
 }


### PR DESCRIPTION
This PR contains:
* better docs for Properties
* less restrictive Property model checks:
  * allows to create `ModelProperty[T]` with `T` containing implemented defs and vals (both for trait and case classes)
  * ModelProperty treats abstract vals in trait as subproperties
* improved compilation error messages