### PR TITLE
Bootstrap wrapper improvements

### DIFF
--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/alert/UdashAlert.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/alert/UdashAlert.scala
@@ -11,9 +11,9 @@ import scalatags.JsDom.all._
 
 sealed class UdashAlert private[alert](alertStyle: AlertStyle, override val componentId: ComponentId)
                                       (content: Modifier*) extends UdashBootstrapComponent {
-  override lazy val render: Element = template().render
+  override val render: Element = template().render
 
-  protected def template() =
+  protected final def template() =
     div(id := componentId, alertStyle, role := "alert")(content: _*)
 }
 
@@ -31,9 +31,9 @@ class DismissibleUdashAlert private[alert](alertStyle: AlertStyle, override val 
   )
   button.listen { case ev => _dismissed.set(true) }
 
-  private lazy val buttonRendered = button.render
+  private val buttonRendered = button.render
 
-  override lazy val render: Element = template()(
+  override val render: Element = template()(
     BootstrapStyles.Alert.alertDismissible,
     buttonRendered, content
   ).render
@@ -55,27 +55,27 @@ trait AlertCompanion[T <: UdashAlert] {
   def success(componentId: ComponentId, content: Modifier*)(implicit ec: ExecutionContext): T =
     create(Success, componentId)(content: _*)
 
-  /** Creates an alert with `Info` style, more: <a href="http://getbootstrap.com/javascript/#alerts">Bootstrap Docs</a>.. */
+  /** Creates an alert with `Info` style, more: <a href="http://getbootstrap.com/javascript/#alerts">Bootstrap Docs</a>. */
   def info(content: Modifier*)(implicit ec: ExecutionContext): T =
     create(Info, UdashBootstrap.newId())(content: _*)
 
-  /** Creates an alert with `Info` style, more: <a href="http://getbootstrap.com/javascript/#alerts">Bootstrap Docs</a>.. */
+  /** Creates an alert with `Info` style, more: <a href="http://getbootstrap.com/javascript/#alerts">Bootstrap Docs</a>. */
   def info(componentId: ComponentId, content: Modifier*)(implicit ec: ExecutionContext): T =
     create(Info, componentId)(content: _*)
 
-  /** Creates an alert with `Warning` style, more: <a href="http://getbootstrap.com/javascript/#alerts">Bootstrap Docs</a>.. */
+  /** Creates an alert with `Warning` style, more: <a href="http://getbootstrap.com/javascript/#alerts">Bootstrap Docs</a>. */
   def warning(content: Modifier*)(implicit ec: ExecutionContext): T =
     create(Warning, UdashBootstrap.newId())(content: _*)
 
-  /** Creates an alert with `Warning` style, more: <a href="http://getbootstrap.com/javascript/#alerts">Bootstrap Docs</a>.. */
+  /** Creates an alert with `Warning` style, more: <a href="http://getbootstrap.com/javascript/#alerts">Bootstrap Docs</a>. */
   def warning(componentId: ComponentId, content: Modifier*)(implicit ec: ExecutionContext): T =
     create(Warning, componentId)(content: _*)
 
-  /** Creates an alert with `Danger` style, more: <a href="http://getbootstrap.com/javascript/#alerts">Bootstrap Docs</a>.. */
+  /** Creates an alert with `Danger` style, more: <a href="http://getbootstrap.com/javascript/#alerts">Bootstrap Docs</a>. */
   def danger(content: Modifier*)(implicit ec: ExecutionContext): T =
     create(Danger, UdashBootstrap.newId())(content: _*)
 
-  /** Creates an alert with `Danger` style, more: <a href="http://getbootstrap.com/javascript/#alerts">Bootstrap Docs</a>.. */
+  /** Creates an alert with `Danger` style, more: <a href="http://getbootstrap.com/javascript/#alerts">Bootstrap Docs</a>. */
   def danger(componentId: ComponentId, content: Modifier*)(implicit ec: ExecutionContext): T =
     create(Danger, componentId)(content: _*)
 }

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/button/UdashButton.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/button/UdashButton.scala
@@ -10,9 +10,10 @@ import org.scalajs.dom._
 import scalatags.JsDom
 import scalatags.JsDom.all._
 
-class UdashButton private(buttonStyle: ButtonStyle, size: ButtonSize, block: Boolean, val active: Property[Boolean],
-                          val disabled: Property[Boolean], override val componentId: ComponentId)
-                         (content: Modifier*) extends UdashBootstrapComponent with Listenable[UdashButton, ButtonClickEvent] {
+final class UdashButton private(buttonStyle: ButtonStyle, size: ButtonSize, block: Boolean, val active: Property[Boolean],
+                                val disabled: Property[Boolean], override val componentId: ComponentId)(content: Modifier*)
+  extends UdashBootstrapComponent with Listenable[UdashButton, ButtonClickEvent] {
+
   import io.udash.css.CssView._
 
   private val classes: List[Modifier] = buttonStyle :: size ::

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/button/UdashButton.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/button/UdashButton.scala
@@ -10,20 +10,19 @@ import org.scalajs.dom._
 import scalatags.JsDom
 import scalatags.JsDom.all._
 
-class UdashButton private(buttonStyle: ButtonStyle, size: ButtonSize, block: Boolean,
-                          val active: Property[Boolean], val disabled: Property[Boolean],
-                          override val componentId: ComponentId)
+class UdashButton private(buttonStyle: ButtonStyle, size: ButtonSize, block: Boolean, val active: Property[Boolean],
+                          val disabled: Property[Boolean], override val componentId: ComponentId)
                          (content: Modifier*) extends UdashBootstrapComponent with Listenable[UdashButton, ButtonClickEvent] {
   import io.udash.css.CssView._
 
-  private lazy val classes: List[Modifier] = buttonStyle :: size ::
+  private val classes: List[Modifier] = buttonStyle :: size ::
     BootstrapStyles.Button.btnBlock.styleIf(block) :: BootstrapStyles.active.styleIf(active) ::
     BootstrapStyles.disabled.styleIf(disabled) :: JsDom.all.disabled.attrIf(disabled) :: Nil
 
-  override lazy val render: dom.html.Button =
+  override val render: dom.html.Button =
     button(id := componentId, tpe := "button")(classes: _*)(
-      onclick :+= ((_: MouseEvent) => {
-        fire(ButtonClickEvent(this))
+      onclick :+= ((me: MouseEvent) => {
+        fire(ButtonClickEvent(this, me))
         false
       })
     )(content: _*).render
@@ -35,9 +34,9 @@ class UdashButton private(buttonStyle: ButtonStyle, size: ButtonSize, block: Boo
     active.listen(v => if (v) selected.set(inputId.id))
     if (active.get) selected.set(inputId.id)
     label(id := componentId)(classes: _*)(
-      onclick :+= ((_: MouseEvent) => {
+      onclick :+= ((me: MouseEvent) => {
         selected.set(inputId.id)
-        fire(ButtonClickEvent(this))
+        fire(ButtonClickEvent(this, me))
         false
       })
     )(in)(content: _*).render
@@ -45,7 +44,7 @@ class UdashButton private(buttonStyle: ButtonStyle, size: ButtonSize, block: Boo
 }
 
 object UdashButton {
-  case class ButtonClickEvent(source: UdashButton) extends ListenableEvent[UdashButton]
+  case class ButtonClickEvent(source: UdashButton, mouseEvent: MouseEvent) extends ListenableEvent[UdashButton]
 
   import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/button/UdashButtonGroup.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/button/UdashButtonGroup.scala
@@ -9,11 +9,11 @@ import org.scalajs.dom
 import scala.concurrent.ExecutionContext
 import scalatags.JsDom.all._
 
-class UdashButtonGroup[ItemType, ElemType <: ReadableProperty[ItemType]] private
-                      (val items: seq.ReadableSeqProperty[ItemType, ElemType],
-                       size: ButtonSize, vertical: Boolean, justified: Boolean, toggle: Boolean,
-                       override val componentId: ComponentId)
-                      (itemFactory: (ElemType) => Seq[dom.Element]) extends UdashBootstrapComponent {
+final class UdashButtonGroup[ItemType, ElemType <: ReadableProperty[ItemType]] private
+                            (val items: seq.ReadableSeqProperty[ItemType, ElemType],
+                             size: ButtonSize, vertical: Boolean, justified: Boolean, toggle: Boolean,
+                             override val componentId: ComponentId)
+                            (itemFactory: (ElemType) => Seq[dom.Element]) extends UdashBootstrapComponent {
   import io.udash.css.CssView._
   import io.udash.bootstrap.BootstrapTags._
 

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/button/UdashButtonGroup.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/button/UdashButtonGroup.scala
@@ -9,20 +9,20 @@ import org.scalajs.dom
 import scala.concurrent.ExecutionContext
 import scalatags.JsDom.all._
 
-class UdashButtonGroup[ItemType, ElemType <: Property[ItemType]] private
-                      (val items: seq.SeqProperty[ItemType, ElemType],
+class UdashButtonGroup[ItemType, ElemType <: ReadableProperty[ItemType]] private
+                      (val items: seq.ReadableSeqProperty[ItemType, ElemType],
                        size: ButtonSize, vertical: Boolean, justified: Boolean, toggle: Boolean,
                        override val componentId: ComponentId)
                       (itemFactory: (ElemType) => Seq[dom.Element]) extends UdashBootstrapComponent {
   import io.udash.css.CssView._
   import io.udash.bootstrap.BootstrapTags._
 
-  private lazy val classes: List[Modifier] = BootstrapStyles.Button.btnGroup ::
+  private val classes: List[Modifier] = BootstrapStyles.Button.btnGroup ::
     BootstrapStyles.Button.btnGroupVertical.styleIf(vertical) ::
     BootstrapStyles.Button.btnGroupJustified.styleIf(justified) ::
     size :: Nil
 
-  override lazy val render: dom.Element = {
+  override val render: dom.Element =
     div(id := componentId, role := "group", classes, if (toggle) dataToggle := "buttons" else ())(
       repeat(items)(
         // "To use justified button groups with <button> elements, you must wrap each button in a button group.
@@ -32,7 +32,6 @@ class UdashButtonGroup[ItemType, ElemType <: Property[ItemType]] private
         else itemFactory
       )
     ).render
-  }
 }
 
 object UdashButtonGroup {
@@ -85,8 +84,8 @@ object UdashButtonGroup {
     * @tparam ElemType Type of the property containing every element in the `items` sequence.
     * @return `UdashButtonGroup` component, call render to create DOM element representing this group.
     */
-  def reactive[ItemType, ElemType <: Property[ItemType]]
-              (items: seq.SeqProperty[ItemType, ElemType],
+  def reactive[ItemType, ElemType <: ReadableProperty[ItemType]]
+              (items: seq.ReadableSeqProperty[ItemType, ElemType],
                size: ButtonSize = ButtonSize.Default, vertical: Boolean = false, justified: Boolean = false,
                componentId: ComponentId = UdashBootstrap.newId())
               (itemFactory: (ElemType) => Seq[dom.Element]): UdashButtonGroup[ItemType, ElemType] =
@@ -103,7 +102,7 @@ object UdashButtonGroup {
     * @param justified If true, buttons will be justified
     * @return `UdashButtonGroup` component, call render to create DOM element representing this group.
     */
-  def checkboxes(items: seq.SeqProperty[CheckboxModel, CastableProperty[CheckboxModel]],
+  def checkboxes(items: seq.ReadableSeqProperty[CheckboxModel, CastableProperty[CheckboxModel]],
                  size: ButtonSize = ButtonSize.Default, vertical: Boolean = false, justified: Boolean = false,
                  componentId: ComponentId = UdashBootstrap.newId()): UdashButtonGroup[CheckboxModel, CastableProperty[CheckboxModel]] =
     new UdashButtonGroup[CheckboxModel, CastableProperty[CheckboxModel]](items, size, vertical, justified, false, componentId)(defaultCheckboxFactory)
@@ -122,7 +121,7 @@ object UdashButtonGroup {
     * @return `UdashButtonGroup` component, call render to create DOM element representing this group.
     */
   def radio[ItemType <: CheckboxModel : ModelPart, ElemType <: CastableProperty[ItemType]]
-           (items: seq.SeqProperty[ItemType, ElemType],
+           (items: seq.ReadableSeqProperty[ItemType, ElemType],
             size: ButtonSize = ButtonSize.Default, vertical: Boolean = false, justified: Boolean = false,
             componentId: ComponentId = UdashBootstrap.newId())
            (implicit ec: ExecutionContext): UdashButtonGroup[ItemType, ElemType] = {

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/button/UdashButtonToolbar.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/button/UdashButtonToolbar.scala
@@ -9,10 +9,12 @@ import org.scalajs.dom
 import scala.concurrent.ExecutionContext
 import scalatags.JsDom.all._
 
-class UdashButtonToolbar[ItemType, ElemType <: ReadableProperty[ItemType]] private
-                        (val items:seq.ReadableSeqProperty[ItemType, ElemType],
-                         override val componentId: ComponentId)
-                        (itemFactory: (ElemType) => Seq[dom.Element]) extends UdashBootstrapComponent {
+final class UdashButtonToolbar[ItemType, ElemType <: ReadableProperty[ItemType]] private
+                              (val items:seq.ReadableSeqProperty[ItemType, ElemType],
+                               override val componentId: ComponentId)
+                              (itemFactory: (ElemType) => Seq[dom.Element])
+  extends UdashBootstrapComponent {
+
   import io.udash.css.CssView._
 
   override val render: dom.Element =

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/button/UdashButtonToolbar.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/button/UdashButtonToolbar.scala
@@ -9,17 +9,16 @@ import org.scalajs.dom
 import scala.concurrent.ExecutionContext
 import scalatags.JsDom.all._
 
-class UdashButtonToolbar[ItemType, ElemType <: Property[ItemType]] private
-                        (val items:seq.SeqProperty[ItemType, ElemType],
+class UdashButtonToolbar[ItemType, ElemType <: ReadableProperty[ItemType]] private
+                        (val items:seq.ReadableSeqProperty[ItemType, ElemType],
                          override val componentId: ComponentId)
                         (itemFactory: (ElemType) => Seq[dom.Element]) extends UdashBootstrapComponent {
   import io.udash.css.CssView._
 
-  override lazy val render: dom.Element = {
+  override val render: dom.Element =
     div(role := "toolbar", BootstrapStyles.Button.btnToolbar)(
       repeat(items)(itemFactory)
     ).render
-  }
 }
 
 object UdashButtonToolbar {
@@ -56,8 +55,8 @@ object UdashButtonToolbar {
     * @tparam ElemType Type of the property containing every element in `items` sequence.
     * @return `UdashButtonToolbar` component, call render to create DOM element representing this toolbar.
     */
-  def reactive[ItemType, ElemType <: Property[ItemType]]
-              (items: seq.SeqProperty[ItemType, ElemType],
+  def reactive[ItemType, ElemType <: ReadableProperty[ItemType]]
+              (items: seq.ReadableSeqProperty[ItemType, ElemType],
                itemFactory: (ElemType) => Seq[dom.Element],
                componentId: ComponentId = UdashBootstrap.newId()): UdashButtonToolbar[ItemType, ElemType] =
     new UdashButtonToolbar[ItemType, ElemType](items, componentId)(itemFactory)

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/carousel/UdashCarousel.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/carousel/UdashCarousel.scala
@@ -19,16 +19,18 @@ import scala.scalajs.js.Dictionary
 import scala.util.Try
 import scalatags.JsDom.all._
 
-class UdashCarousel private(content: ReadableSeqProperty[UdashCarouselSlide], val componentId: ComponentId,
-                            showIndicators: Boolean, activeSlide: Int, animationOptions: AnimationOptions)
-                           (implicit ec: ExecutionContext) extends UdashBootstrapComponent with Listenable[UdashCarousel, CarouselEvent] {
-  import io.udash.css.CssView._
-  require(activeSlide >= 0, "Active slide index cannot be negative.")
+final class UdashCarousel private(content: ReadableSeqProperty[UdashCarouselSlide], val componentId: ComponentId,
+                                  showIndicators: Boolean, activeSlide: Int, animationOptions: AnimationOptions)
+                                 (implicit ec: ExecutionContext)
+  extends UdashBootstrapComponent with Listenable[UdashCarousel, CarouselEvent] {
 
   import BootstrapStyles.Carousel._
   import BootstrapTags._
   import UdashCarousel._
   import io.udash.wrappers.jquery._
+  import io.udash.css.CssView._
+
+  require(activeSlide >= 0, "Active slide index cannot be negative.")
 
   private val indices = content.transform((slides: Seq[UdashCarouselSlide]) => slides.length)
   private val _activeIndex: Property[Int] = Property[Int](firstActive)

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/carousel/UdashCarousel.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/carousel/UdashCarousel.scala
@@ -19,7 +19,7 @@ import scala.scalajs.js.Dictionary
 import scala.util.Try
 import scalatags.JsDom.all._
 
-class UdashCarousel private(val content: SeqProperty[UdashCarouselSlide], val componentId: ComponentId,
+class UdashCarousel private(content: ReadableSeqProperty[UdashCarouselSlide], val componentId: ComponentId,
                             showIndicators: Boolean, activeSlide: Int, animationOptions: AnimationOptions)
                            (implicit ec: ExecutionContext) extends UdashBootstrapComponent with Listenable[UdashCarousel, CarouselEvent] {
   import io.udash.css.CssView._
@@ -30,14 +30,14 @@ class UdashCarousel private(val content: SeqProperty[UdashCarouselSlide], val co
   import UdashCarousel._
   import io.udash.wrappers.jquery._
 
-  private lazy val indices = content.transform((slides: Seq[UdashCarouselSlide]) => slides.length)
-  private lazy val _activeIndex: Property[Int] = Property[Int](firstActive)
+  private val indices = content.transform((slides: Seq[UdashCarouselSlide]) => slides.length)
+  private val _activeIndex: Property[Int] = Property[Int](firstActive)
 
   content.listen(slides => _activeIndex.set(slides.zipWithIndex.collectFirst {
     case (sl, idx) if jQ(sl.render).hasClass(BootstrapStyles.active.className) => idx
   }.get))
 
-  override lazy val render: Element = {
+  override val render: Element = {
     def indicators() = {
       def indicator(index: Int) =
         li(
@@ -161,7 +161,7 @@ object UdashCarousel {
     * @param ec               ExecutionContext for carousel internal properties
     * @return `UdashCarousel` component
     */
-  def apply(content: SeqProperty[UdashCarouselSlide], componentId: ComponentId = UdashBootstrap.newId(),
+  def apply(content: ReadableSeqProperty[UdashCarouselSlide], componentId: ComponentId = UdashBootstrap.newId(),
             showIndicators: Boolean = true, activeSlide: Int = 0, animationOptions: AnimationOptions = AnimationOptions())
            (implicit ec: ExecutionContext): UdashCarousel =
     new UdashCarousel(content, componentId, showIndicators, activeSlide, animationOptions)

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/collapse/UdashAccordion.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/collapse/UdashAccordion.scala
@@ -2,6 +2,7 @@ package io.udash.bootstrap
 package collapse
 
 import io.udash._
+import io.udash.properties.seq
 import io.udash.bootstrap.UdashBootstrap.ComponentId
 import io.udash.bootstrap.panel.{PanelStyle, UdashPanel}
 import io.udash.properties.seq.SeqProperty
@@ -10,8 +11,8 @@ import org.scalajs.dom._
 
 import scala.collection.mutable
 
-class UdashAccordion[ItemType, ElemType <: Property[ItemType]] private
-                    (panels: SeqProperty[ItemType, ElemType], override val componentId: ComponentId)
+class UdashAccordion[ItemType, ElemType <: ReadableProperty[ItemType]] private
+                    (panels: seq.ReadableSeqProperty[ItemType, ElemType], override val componentId: ComponentId)
                     (panelStyleSelector: ItemType => PanelStyle,
                      heading: (ElemType) => dom.Element,
                      body: (ElemType) => dom.Element) extends UdashBootstrapComponent {
@@ -26,7 +27,7 @@ class UdashAccordion[ItemType, ElemType <: Property[ItemType]] private
   def collapseOf(panel: ElemType): Option[UdashCollapse] =
     collapses.get(panel)
 
-  override lazy val render: Element =
+  override val render: Element =
     div(BootstrapStyles.Panel.panelGroup, id := componentId, role := "tablist", aria.multiselectable := true)(
       repeat(panels)(item => {
         val headingId = UdashBootstrap.newId()
@@ -65,8 +66,8 @@ object UdashAccordion {
     * @tparam ElemType Type of the property containing every element in `items` sequence.
     * @return `UdashAccordion` component, call render to create DOM element.
     */
-  def apply[ItemType, ElemType <: Property[ItemType]]
-           (panels: SeqProperty[ItemType, ElemType], componentId: ComponentId = UdashBootstrap.newId())
+  def apply[ItemType, ElemType <: ReadableProperty[ItemType]]
+           (panels: seq.ReadableSeqProperty[ItemType, ElemType], componentId: ComponentId = UdashBootstrap.newId())
            (heading: (ElemType) => Element, body: (ElemType) => Element,
             panelTypeSelector: ItemType => PanelStyle = (_: ItemType) => PanelStyle.Default): UdashAccordion[ItemType, ElemType] =
     new UdashAccordion(panels, componentId)(panelTypeSelector, heading, body)

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/collapse/UdashAccordion.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/collapse/UdashAccordion.scala
@@ -11,11 +11,13 @@ import org.scalajs.dom._
 
 import scala.collection.mutable
 
-class UdashAccordion[ItemType, ElemType <: ReadableProperty[ItemType]] private
-                    (panels: seq.ReadableSeqProperty[ItemType, ElemType], override val componentId: ComponentId)
-                    (panelStyleSelector: ItemType => PanelStyle,
-                     heading: (ElemType) => dom.Element,
-                     body: (ElemType) => dom.Element) extends UdashBootstrapComponent {
+final class UdashAccordion[ItemType, ElemType <: ReadableProperty[ItemType]] private
+                          (panels: seq.ReadableSeqProperty[ItemType, ElemType], override val componentId: ComponentId)
+                          (panelStyleSelector: ItemType => PanelStyle,
+                           heading: (ElemType) => dom.Element,
+                           body: (ElemType) => dom.Element)
+  extends UdashBootstrapComponent {
+
   import io.udash.css.CssView._
   import BootstrapTags._
 

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/collapse/UdashCollapse.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/collapse/UdashCollapse.scala
@@ -10,7 +10,8 @@ import scala.scalajs.js
 import scalatags.JsDom.all._
 import scalatags.generic.AttrPair
 
-class UdashCollapse private(parentSelector: Option[String], toggleOnInit: Boolean, override val componentId: ComponentId)(content: Modifier*)
+final class UdashCollapse private(parentSelector: Option[String], toggleOnInit: Boolean,
+                                  override val componentId: ComponentId)(content: Modifier*)
   extends UdashBootstrapComponent with Listenable[UdashCollapse, UdashCollapse.CollapseEvent] {
 
   import io.udash.css.CssView._

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/collapse/UdashCollapse.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/collapse/UdashCollapse.scala
@@ -37,7 +37,7 @@ class UdashCollapse private(parentSelector: Option[String], toggleOnInit: Boolea
     )
   }
 
-  override lazy val render: Element = {
+  override val render: Element = {
     val el = div(
       dataParent := parentSelector.getOrElse("false"), dataToggle := toggleOnInit,
       BootstrapStyles.Collapse.collapse, id := componentId

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/datepicker/UdashDatePicker.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/datepicker/UdashDatePicker.scala
@@ -16,9 +16,9 @@ import scala.scalajs.js.|
 import scala.util.Try
 
 /** Wrapper for <a href="http://eonasdan.github.io/bootstrap-datetimepicker/">Bootstrap 3 Datepicker</a>. */
-class UdashDatePicker private[datepicker](val date: Property[Option[ju.Date]],
-                                          val options: ReadableProperty[UdashDatePicker.DatePickerOptions],
-                                          override val componentId: ComponentId)
+final class UdashDatePicker private[datepicker](val date: Property[Option[ju.Date]],
+                                                val options: ReadableProperty[UdashDatePicker.DatePickerOptions],
+                                                override val componentId: ComponentId)
   extends UdashBootstrapComponent with Listenable[UdashDatePicker, UdashDatePicker.DatePickerEvent] with StrictLogging {
 
   import io.udash.css.CssView._

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/datepicker/UdashDatePicker.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/datepicker/UdashDatePicker.scala
@@ -26,8 +26,8 @@ class UdashDatePicker private[datepicker](val date: Property[Option[ju.Date]],
 
   import scalatags.JsDom.all._
 
-  private lazy val inp = input(id := componentId.id, tpe := "text", BootstrapStyles.Form.formControl).render
-  private lazy val jQInput = jQ(inp).asDatePicker()
+  private val inp = input(id := componentId.id, tpe := "text", BootstrapStyles.Form.formControl).render
+  private val jQInput = jQ(inp).asDatePicker()
 
   /** Shows date picker widget. */
   def show(): Unit =
@@ -49,7 +49,7 @@ class UdashDatePicker private[datepicker](val date: Property[Option[ju.Date]],
   def disable(): Unit =
     jQInput.dpData().disable()
 
-  lazy val render: dom.Element = {
+  val render: dom.Element = {
     jQInput.datetimepicker(optionsToJsDict(options.get))
 
     options.listen(opts => jQInput.dpData().options(optionsToJsDict(opts)))

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/dropdown/UdashDropdown.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/dropdown/UdashDropdown.scala
@@ -11,9 +11,10 @@ import org.scalajs.dom
 import scala.scalajs.js
 import scalatags.JsDom.all._
 
-class UdashDropdown[ItemType, ElemType <: ReadableProperty[ItemType]] private
-                   (val items: seq.ReadableSeqProperty[ItemType, ElemType], dropup: Boolean, override val componentId: ComponentId)
-                   (itemFactory: (ElemType) => dom.Element)(content: Modifier*)
+final class UdashDropdown[ItemType, ElemType <: ReadableProperty[ItemType]] private
+                         (val items: seq.ReadableSeqProperty[ItemType, ElemType], dropup: Boolean,
+                          override val componentId: ComponentId)
+                         (itemFactory: (ElemType) => dom.Element)(content: Modifier*)
   extends UdashBootstrapComponent with Listenable[UdashDropdown[ItemType, ElemType], UdashDropdown.DropdownEvent[ItemType, ElemType]] {
 
   import io.udash.css.CssView._

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/dropdown/UdashDropdown.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/dropdown/UdashDropdown.scala
@@ -11,8 +11,8 @@ import org.scalajs.dom
 import scala.scalajs.js
 import scalatags.JsDom.all._
 
-class UdashDropdown[ItemType, ElemType <: Property[ItemType]] private
-                   (val items: seq.SeqProperty[ItemType, ElemType], dropup: Boolean, override val componentId: ComponentId)
+class UdashDropdown[ItemType, ElemType <: ReadableProperty[ItemType]] private
+                   (val items: seq.ReadableSeqProperty[ItemType, ElemType], dropup: Boolean, override val componentId: ComponentId)
                    (itemFactory: (ElemType) => dom.Element)(content: Modifier*)
   extends UdashBootstrapComponent with Listenable[UdashDropdown[ItemType, ElemType], UdashDropdown.DropdownEvent[ItemType, ElemType]] {
 
@@ -80,12 +80,12 @@ class UdashDropdown[ItemType, ElemType <: Property[ItemType]] private
 }
 
 object UdashDropdown {
-  sealed abstract class DropdownEvent[ItemType, ElemType <: Property[ItemType]](override val source: UdashDropdown[ItemType, ElemType]) extends ListenableEvent[UdashDropdown[ItemType, ElemType]]
-  case class DropdownShowEvent[ItemType, ElemType <: Property[ItemType]](dropdown: UdashDropdown[ItemType, ElemType]) extends DropdownEvent(dropdown)
-  case class DropdownShownEvent[ItemType, ElemType <: Property[ItemType]](dropdown: UdashDropdown[ItemType, ElemType]) extends DropdownEvent(dropdown)
-  case class DropdownHideEvent[ItemType, ElemType <: Property[ItemType]](dropdown: UdashDropdown[ItemType, ElemType]) extends DropdownEvent(dropdown)
-  case class DropdownHiddenEvent[ItemType, ElemType <: Property[ItemType]](dropdown: UdashDropdown[ItemType, ElemType]) extends DropdownEvent(dropdown)
-  case class SelectionEvent[ItemType, ElemType <: Property[ItemType]](dropdown: UdashDropdown[ItemType, ElemType], item: ItemType) extends DropdownEvent(dropdown)
+  sealed abstract class DropdownEvent[ItemType, ElemType <: ReadableProperty[ItemType]](override val source: UdashDropdown[ItemType, ElemType]) extends ListenableEvent[UdashDropdown[ItemType, ElemType]]
+  case class DropdownShowEvent[ItemType, ElemType <: ReadableProperty[ItemType]](dropdown: UdashDropdown[ItemType, ElemType]) extends DropdownEvent(dropdown)
+  case class DropdownShownEvent[ItemType, ElemType <: ReadableProperty[ItemType]](dropdown: UdashDropdown[ItemType, ElemType]) extends DropdownEvent(dropdown)
+  case class DropdownHideEvent[ItemType, ElemType <: ReadableProperty[ItemType]](dropdown: UdashDropdown[ItemType, ElemType]) extends DropdownEvent(dropdown)
+  case class DropdownHiddenEvent[ItemType, ElemType <: ReadableProperty[ItemType]](dropdown: UdashDropdown[ItemType, ElemType]) extends DropdownEvent(dropdown)
+  case class SelectionEvent[ItemType, ElemType <: ReadableProperty[ItemType]](dropdown: UdashDropdown[ItemType, ElemType], item: ItemType) extends DropdownEvent(dropdown)
 
   /** Default dropdown elements. */
   sealed trait DefaultDropdownItem
@@ -101,7 +101,7 @@ object UdashDropdown {
   }
 
   /** Renders DOM element for [[io.udash.bootstrap.dropdown.UdashDropdown.DefaultDropdownItem]]. */
-  def defaultItemFactory(p: Property[DefaultDropdownItem]): dom.Element = {
+  def defaultItemFactory(p: ReadableProperty[DefaultDropdownItem]): dom.Element = {
     import io.udash.css.CssView._
     def itemFactory(item: DefaultDropdownItem): dom.Element = item match {
       case DropdownLink(title, url) => li(a(href := url.value)(produce(p)(_ => span(title).render))).render
@@ -124,8 +124,8 @@ object UdashDropdown {
     * @tparam ElemType Type of the property containing every element in `items` sequence.
     * @return `UdashDropdown` component, call render to create DOM element.
     */
-  def apply[ItemType, ElemType <: Property[ItemType]]
-           (items: seq.SeqProperty[ItemType, ElemType], componentId: ComponentId = UdashBootstrap.newId())
+  def apply[ItemType, ElemType <: ReadableProperty[ItemType]]
+           (items: seq.ReadableSeqProperty[ItemType, ElemType], componentId: ComponentId = UdashBootstrap.newId())
            (itemFactory: (ElemType) => dom.Element)
            (content: Modifier*): UdashDropdown[ItemType, ElemType] =
     new UdashDropdown(items, false, componentId)(itemFactory)(content)
@@ -142,8 +142,8 @@ object UdashDropdown {
     * @tparam ElemType Type of the property containing every element in `items` sequence.
     * @return `UdashDropdown` component, call render to create DOM element.
     */
-  def dropup[ItemType, ElemType <: Property[ItemType]]
-            (items: seq.SeqProperty[ItemType, ElemType], componentId: ComponentId = UdashBootstrap.newId())
+  def dropup[ItemType, ElemType <: ReadableProperty[ItemType]]
+            (items: seq.ReadableSeqProperty[ItemType, ElemType], componentId: ComponentId = UdashBootstrap.newId())
             (itemFactory: (ElemType) => dom.Element)
             (content: Modifier*): UdashDropdown[ItemType, ElemType] =
     new UdashDropdown(items, true, componentId)(itemFactory)(content)

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/form/UdashForm.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/form/UdashForm.scala
@@ -10,9 +10,11 @@ import org.scalajs.dom._
 import scala.util.{Failure, Success}
 import scalatags.JsDom.all._
 
-class UdashForm private(formStyle: Option[CssStyle], override val componentId: ComponentId)
-                       (content: Modifier*) extends UdashBootstrapComponent {
+final class UdashForm private(formStyle: Option[CssStyle], override val componentId: ComponentId)
+                             (content: Modifier*) extends UdashBootstrapComponent {
+
   import io.udash.css.CssView._
+
   override val render =
     form(if (formStyle.isDefined) formStyle.get else ())(
       content

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/form/UdashForm.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/form/UdashForm.scala
@@ -13,7 +13,7 @@ import scalatags.JsDom.all._
 class UdashForm private(formStyle: Option[CssStyle], override val componentId: ComponentId)
                        (content: Modifier*) extends UdashBootstrapComponent {
   import io.udash.css.CssView._
-  override lazy val render =
+  override val render =
     form(if (formStyle.isDefined) formStyle.get else ())(
       content
     ).render
@@ -24,7 +24,7 @@ object UdashForm {
   import io.udash.css.CssView._
 
   /** Binds provided `property` validation result to element Bootstrap validation style. */
-  def validation(property: Property[_]): Modifier =
+  def validation(property: ReadableProperty[_]): Modifier =
     property.reactiveApply((el, _) => {
       import BootstrapStyles.Form._
       Seq(hasSuccess, hasError, hasWarning).foreach(_.removeFrom(el))
@@ -121,7 +121,7 @@ object UdashForm {
   private def inputGroup(inputId: ComponentId, validation: Option[Modifier])
                         (labelContent: Modifier*)(input: dom.Element): Modifier =
     group(
-      label(`for` := inputId)(labelContent),
+      if (labelContent.nonEmpty) label(`for` := inputId)(labelContent) else (),
       UdashForm.input(input),
       validation
     )
@@ -148,7 +148,7 @@ object UdashForm {
 
   /** Creates file input input group. */
   def fileInput(inputId: ComponentId = UdashBootstrap.newId(), validation: Option[Modifier] = None)(labelContent: Modifier*)
-               (name: String, acceptMultipleFiles: Property[Boolean], selectedFiles: SeqProperty[File], input: Modifier*): Modifier =
+               (name: String, acceptMultipleFiles: ReadableProperty[Boolean], selectedFiles: SeqProperty[File], input: Modifier*): Modifier =
     inputGroup(inputId, validation)(labelContent)(FileInput(name, acceptMultipleFiles, selectedFiles)((id := inputId) +: input))
 
   /** Creates checkbox. */
@@ -205,6 +205,6 @@ object UdashForm {
     *
     * @param disabled Property indicating if elements are disabled. You can change it anytime.
     */
-  def disabled(disabled: Property[Boolean] = Property(true))(content: Modifier*): Modifier =
+  def disabled(disabled: ReadableProperty[Boolean] = Property(true))(content: Modifier*): Modifier =
     fieldset((scalatags.JsDom.attrs.disabled := "disabled").attrIf(disabled))(content)
 }

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/form/UdashInputGroup.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/form/UdashInputGroup.scala
@@ -8,7 +8,7 @@ import scalatags.JsDom.all._
 
 class UdashInputGroup private(groupSize: InputGroupSize, override val componentId: ComponentId)(content: Modifier*) extends UdashBootstrapComponent {
   import io.udash.css.CssView._
-  override lazy val render =
+  override val render: dom.Element =
     div(BootstrapStyles.Form.inputGroup, groupSize)(
       content
     ).render

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/form/UdashInputGroup.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/form/UdashInputGroup.scala
@@ -6,8 +6,11 @@ import org.scalajs.dom
 
 import scalatags.JsDom.all._
 
-class UdashInputGroup private(groupSize: InputGroupSize, override val componentId: ComponentId)(content: Modifier*) extends UdashBootstrapComponent {
+final class UdashInputGroup private(groupSize: InputGroupSize, override val componentId: ComponentId)(content: Modifier*)
+  extends UdashBootstrapComponent {
+
   import io.udash.css.CssView._
+
   override val render: dom.Element =
     div(BootstrapStyles.Form.inputGroup, groupSize)(
       content

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/label/UdashLabel.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/label/UdashLabel.scala
@@ -7,7 +7,9 @@ import org.scalajs.dom
 
 import scalatags.JsDom.all._
 
-class UdashLabel private(style: LabelStyle, override val componentId: ComponentId)(mds: Modifier*) extends UdashBootstrapComponent {
+final class UdashLabel private(style: LabelStyle, override val componentId: ComponentId)(mds: Modifier*)
+  extends UdashBootstrapComponent {
+
   override val render: dom.Element =
     span(id := componentId, style)(mds: _*).render
 }

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/label/UdashLabel.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/label/UdashLabel.scala
@@ -8,7 +8,7 @@ import org.scalajs.dom
 import scalatags.JsDom.all._
 
 class UdashLabel private(style: LabelStyle, override val componentId: ComponentId)(mds: Modifier*) extends UdashBootstrapComponent {
-  override lazy val render: dom.Element =
+  override val render: dom.Element =
     span(id := componentId, style)(mds: _*).render
 }
 
@@ -21,7 +21,7 @@ object UdashLabel {
     * @param componentId Id of the root DOM node.
     * @return `UdashLabel` component, call render to create DOM element.
     */
-  def apply(content: Property[_], componentId: ComponentId = UdashBootstrap.newId()): UdashLabel =
+  def apply(content: ReadableProperty[_], componentId: ComponentId = UdashBootstrap.newId()): UdashLabel =
     new UdashLabel(LabelStyle.Default, componentId)(bind(content))
 
   /**
@@ -43,7 +43,7 @@ object UdashLabel {
     * @param componentId Id of the root DOM node.
     * @return `UdashLabel` component, call render to create DOM element.
     */
-  def primary(content: Property[_], componentId: ComponentId = UdashBootstrap.newId()): UdashLabel =
+  def primary(content: ReadableProperty[_], componentId: ComponentId = UdashBootstrap.newId()): UdashLabel =
     new UdashLabel(LabelStyle.Primary, componentId)(bind(content))
 
   /**
@@ -65,7 +65,7 @@ object UdashLabel {
     * @param componentId Id of the root DOM node.
     * @return `UdashLabel` component, call render to create DOM element.
     */
-  def success(content: Property[_], componentId: ComponentId = UdashBootstrap.newId()): UdashLabel =
+  def success(content: ReadableProperty[_], componentId: ComponentId = UdashBootstrap.newId()): UdashLabel =
     new UdashLabel(LabelStyle.Success, componentId)(bind(content))
 
   /**
@@ -87,7 +87,7 @@ object UdashLabel {
     * @param componentId Id of the root DOM node.
     * @return `UdashLabel` component, call render to create DOM element.
     */
-  def info(content: Property[_], componentId: ComponentId = UdashBootstrap.newId()): UdashLabel =
+  def info(content: ReadableProperty[_], componentId: ComponentId = UdashBootstrap.newId()): UdashLabel =
     new UdashLabel(LabelStyle.Info, componentId)(bind(content))
 
   /**
@@ -109,7 +109,7 @@ object UdashLabel {
     * @param componentId Id of the root DOM node.
     * @return `UdashLabel` component, call render to create DOM element.
     */
-  def warning(content: Property[_], componentId: ComponentId = UdashBootstrap.newId()): UdashLabel =
+  def warning(content: ReadableProperty[_], componentId: ComponentId = UdashBootstrap.newId()): UdashLabel =
     new UdashLabel(LabelStyle.Warning, componentId)(bind(content))
 
   /**
@@ -131,7 +131,7 @@ object UdashLabel {
     * @param componentId Id of the root DOM node.
     * @return `UdashLabel` component, call render to create DOM element.
     */
-  def danger(content: Property[_], componentId: ComponentId = UdashBootstrap.newId()): UdashLabel =
+  def danger(content: ReadableProperty[_], componentId: ComponentId = UdashBootstrap.newId()): UdashLabel =
     new UdashLabel(LabelStyle.Danger, componentId)(bind(content))
 
   /**

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/modal/UdashModal.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/modal/UdashModal.scala
@@ -8,11 +8,12 @@ import org.scalajs.dom.Element
 
 import scala.scalajs.js
 
-class UdashModal private(modalSize: ModalSize, fade: Boolean, labelId: String,
-                         backdrop: UdashModal.BackdropType, keyboard: Boolean, autoInit: Boolean, override val componentId: ComponentId)
-                        (headerFactory: Option[() => dom.Element],
-                         bodyFactory: Option[() => dom.Element],
-                         footerFactory: Option[() => dom.Element])
+final class UdashModal private(modalSize: ModalSize, fade: Boolean, labelId: String,
+                               backdrop: UdashModal.BackdropType, keyboard: Boolean,
+                               autoInit: Boolean, override val componentId: ComponentId)
+                              (headerFactory: Option[() => dom.Element],
+                               bodyFactory: Option[() => dom.Element],
+                               footerFactory: Option[() => dom.Element])
   extends UdashBootstrapComponent with Listenable[UdashModal, UdashModal.ModalEvent] {
 
   import io.udash.css.CssView._

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/modal/UdashModal.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/modal/UdashModal.scala
@@ -43,7 +43,7 @@ class UdashModal private(modalSize: ModalSize, fade: Boolean, labelId: String,
       dataTarget := s"#$componentId"
     )
 
-  override lazy val render: Element = {
+  override val render: Element = {
     val content = Seq(
       (headerFactory, BootstrapStyles.Modal.modalHeader),
       (bodyFactory, BootstrapStyles.Modal.modalBody),

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/navs/UdashNav.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/navs/UdashNav.scala
@@ -9,13 +9,13 @@ import org.scalajs.dom
 
 import scalatags.JsDom.all._
 
-class UdashNav[ItemType, ElemType <: ReadableProperty[ItemType]] private
-              (navStyle: CssStyle, stacked: Boolean, justified: Boolean, override val componentId: ComponentId)
-              (val panels: seq.ReadableSeqProperty[ItemType, ElemType])
-              (elemFactory: (ElemType) => dom.Node,
-               isActive: (ElemType) => ReadableProperty[Boolean],
-               isDisabled: (ElemType) => ReadableProperty[Boolean],
-               isDropdown: (ElemType) => ReadableProperty[Boolean])
+final class UdashNav[ItemType, ElemType <: ReadableProperty[ItemType]] private
+                    (navStyle: CssStyle, stacked: Boolean, justified: Boolean, override val componentId: ComponentId)
+                    (val panels: seq.ReadableSeqProperty[ItemType, ElemType])
+                    (elemFactory: (ElemType) => dom.Node,
+                     isActive: (ElemType) => ReadableProperty[Boolean],
+                     isDisabled: (ElemType) => ReadableProperty[Boolean],
+                     isDropdown: (ElemType) => ReadableProperty[Boolean])
   extends UdashBootstrapComponent {
   import io.udash.css.CssView._
 

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/navs/UdashNav.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/navs/UdashNav.scala
@@ -3,15 +3,15 @@ package navs
 
 import io.udash.bootstrap.UdashBootstrap.ComponentId
 import io.udash.css.CssStyle
-import io.udash.properties.seq.SeqProperty
+import io.udash.properties.seq
 import io.udash.{properties, _}
 import org.scalajs.dom
 
 import scalatags.JsDom.all._
 
-class UdashNav[ItemType, ElemType <: Property[ItemType]] private
+class UdashNav[ItemType, ElemType <: ReadableProperty[ItemType]] private
               (navStyle: CssStyle, stacked: Boolean, justified: Boolean, override val componentId: ComponentId)
-              (val panels: SeqProperty[ItemType, ElemType])
+              (val panels: seq.ReadableSeqProperty[ItemType, ElemType])
               (elemFactory: (ElemType) => dom.Node,
                isActive: (ElemType) => ReadableProperty[Boolean],
                isDisabled: (ElemType) => ReadableProperty[Boolean],
@@ -19,7 +19,7 @@ class UdashNav[ItemType, ElemType <: Property[ItemType]] private
   extends UdashBootstrapComponent {
   import io.udash.css.CssView._
 
-  override lazy val render: dom.Element =
+  override val render: dom.Element =
     ul(
       id := componentId,
       BootstrapStyles.Navigation.nav, navStyle,
@@ -53,9 +53,9 @@ object UdashNav {
     * @tparam ElemType Type of the property containing every element in `items` sequence.
     * @return `UdashNav` component, call render to create DOM element.
     */
-  def apply[ItemType, ElemType <: Property[ItemType]]
+  def apply[ItemType, ElemType <: ReadableProperty[ItemType]]
            (stacked: Boolean = false, justified: Boolean = false, componentId: ComponentId = UdashBootstrap.newId())
-           (panels: SeqProperty[ItemType, ElemType])
+           (panels: seq.ReadableSeqProperty[ItemType, ElemType])
            (elemFactory: (ElemType) => dom.Node,
             isActive: (ElemType) => ReadableProperty[Boolean] = (_: ElemType) => Property(false),
             isDisabled: (ElemType) => ReadableProperty[Boolean] = (_: ElemType) => Property(false),
@@ -76,9 +76,9 @@ object UdashNav {
     * @tparam ElemType Type of the property containing every element in `items` sequence.
     * @return `UdashNav` component, call render to create DOM element.
     */
-  def pills[ItemType, ElemType <: Property[ItemType]]
+  def pills[ItemType, ElemType <: ReadableProperty[ItemType]]
            (stacked: Boolean = false, justified: Boolean = false, componentId: ComponentId = UdashBootstrap.newId())
-           (panels: SeqProperty[ItemType, ElemType])
+           (panels: seq.ReadableSeqProperty[ItemType, ElemType])
            (elemFactory: (ElemType) => dom.Node,
             isActive: (ElemType) => ReadableProperty[Boolean] = (_: ElemType) => Property(false),
             isDisabled: (ElemType) => ReadableProperty[Boolean] = (_: ElemType) => Property(false),
@@ -99,9 +99,9 @@ object UdashNav {
     * @tparam ElemType Type of the property containing every element in `items` sequence.
     * @return `UdashNav` component, call render to create DOM element.
     */
-  def tabs[ItemType, ElemType <: Property[ItemType]]
+  def tabs[ItemType, ElemType <: ReadableProperty[ItemType]]
           (stacked: Boolean = false, justified: Boolean = false, componentId: ComponentId = UdashBootstrap.newId())
-          (panels: SeqProperty[ItemType, ElemType])
+          (panels: seq.ReadableSeqProperty[ItemType, ElemType])
           (elemFactory: (ElemType) => dom.Node,
            isActive: (ElemType) => ReadableProperty[Boolean] = (_: ElemType) => Property(false),
            isDisabled: (ElemType) => ReadableProperty[Boolean] = (_: ElemType) => Property(false),
@@ -122,8 +122,8 @@ object UdashNav {
     * @tparam ElemType Type of the property containing every element in `items` sequence.
     * @return `UdashNav` component, call render to create DOM element.
     */
-  def navbar[ItemType, ElemType <: Property[ItemType]]
-            (panels: SeqProperty[ItemType, ElemType], componentId: ComponentId = UdashBootstrap.newId())
+  def navbar[ItemType, ElemType <: ReadableProperty[ItemType]]
+            (panels: seq.ReadableSeqProperty[ItemType, ElemType], componentId: ComponentId = UdashBootstrap.newId())
             (elemFactory: (ElemType) => dom.Node,
              isActive: (ElemType) => ReadableProperty[Boolean] = (_: ElemType) => Property(false),
              isDisabled: (ElemType) => ReadableProperty[Boolean] = (_: ElemType) => Property(false),

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/navs/UdashNavbar.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/navs/UdashNavbar.scala
@@ -9,7 +9,7 @@ import org.scalajs.dom
 import scalatags.JsDom.all._
 import scalatags.JsDom.tags2
 
-class UdashNavbar[ItemType, ElemType <: Property[ItemType]] private
+class UdashNavbar[ItemType, ElemType <: ReadableProperty[ItemType]] private
                  (navbarStyle: CssStyle, override val componentId: ComponentId)
                  (brand: dom.Element, nav: UdashNav[ItemType, ElemType])
   extends UdashBootstrapComponent {
@@ -19,7 +19,7 @@ class UdashNavbar[ItemType, ElemType <: Property[ItemType]] private
 
   private val collapseId = UdashBootstrap.newId()
 
-  override lazy val render: dom.Element =
+  override val render: dom.Element =
     tags2.nav(id := componentId, BootstrapStyles.Navigation.navbar, navbarStyle)(
       div(BootstrapStyles.containerFluid)(
         div(BootstrapStyles.Navigation.navbarHeader)(
@@ -48,7 +48,7 @@ object UdashNavbar {
     * @tparam ElemType Type of the property containing every element in `items` sequence.
     * @return `UdashNavbar` component, call render to create DOM element.
     */
-  def apply[ItemType, ElemType <: Property[ItemType]]
+  def apply[ItemType, ElemType <: ReadableProperty[ItemType]]
            (brand: dom.Element, nav: UdashNav[ItemType, ElemType], componentId: ComponentId = UdashBootstrap.newId()): UdashNavbar[ItemType, ElemType] =
     new UdashNavbar(BootstrapStyles.Navigation.navbarDefault, componentId)(brand, nav)
 
@@ -62,7 +62,7 @@ object UdashNavbar {
     * @tparam ElemType Type of the property containing every element in `items` sequence.
     * @return `UdashNavbar` component, call render to create DOM element.
     */
-  def inverted[ItemType, ElemType <: Property[ItemType]]
+  def inverted[ItemType, ElemType <: ReadableProperty[ItemType]]
               (brand: dom.Element, nav: UdashNav[ItemType, ElemType], componentId: ComponentId = UdashBootstrap.newId()): UdashNavbar[ItemType, ElemType] =
     new UdashNavbar(BootstrapStyles.Navigation.navbarInverse, componentId)(brand, nav)
 }

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/navs/UdashNavbar.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/navs/UdashNavbar.scala
@@ -9,9 +9,9 @@ import org.scalajs.dom
 import scalatags.JsDom.all._
 import scalatags.JsDom.tags2
 
-class UdashNavbar[ItemType, ElemType <: ReadableProperty[ItemType]] private
-                 (navbarStyle: CssStyle, override val componentId: ComponentId)
-                 (brand: dom.Element, nav: UdashNav[ItemType, ElemType])
+final class UdashNavbar[ItemType, ElemType <: ReadableProperty[ItemType]] private
+                       (navbarStyle: CssStyle, override val componentId: ComponentId)
+                       (brand: dom.Element, nav: UdashNav[ItemType, ElemType])
   extends UdashBootstrapComponent {
 
   import io.udash.css.CssView._

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/pagination/UdashPagination.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/pagination/UdashPagination.scala
@@ -10,9 +10,9 @@ import org.scalajs.dom.Event
 
 import scala.concurrent.ExecutionContext
 
-sealed trait PaginationComponent[PageType, ElemType <: Property[PageType]] extends UdashBootstrapComponent {
+sealed trait PaginationComponent[PageType, ElemType <: ReadableProperty[PageType]] extends UdashBootstrapComponent {
   /** Sequence of pagination elements. Pagination will automatically synchronize with this property changes. */
-  def pages: seq.SeqProperty[PageType, ElemType]
+  def pages: seq.ReadableSeqProperty[PageType, ElemType]
 
   /** Index of selected page. */
   def selectedPage: Property[Int]
@@ -30,14 +30,15 @@ sealed trait PaginationComponent[PageType, ElemType <: Property[PageType]] exten
   def previous(): Unit = changePage(selectedPage.get - 1)
 }
 
-class UdashPagination[PageType : ModelValue, ElemType <: Property[PageType]] private
-                     (size: PaginationSize, showArrows: Property[Boolean], highlightActive: Property[Boolean], override val componentId: ComponentId)
-                     (val pages: seq.SeqProperty[PageType, ElemType], val selectedPage: Property[Int])
+class UdashPagination[PageType : ModelValue, ElemType <: ReadableProperty[PageType]] private
+                     (size: PaginationSize, showArrows: ReadableProperty[Boolean],
+                      highlightActive: ReadableProperty[Boolean], override val componentId: ComponentId)
+                     (val pages: seq.ReadableSeqProperty[PageType, ElemType], val selectedPage: Property[Int])
                      (itemFactory: (ElemType, UdashPagination.ButtonType) => dom.Element)(implicit ec: ExecutionContext)
   extends PaginationComponent[PageType, ElemType] {
   import io.udash.css.CssView._
 
-  override lazy val render: dom.Element = {
+  override val render: dom.Element = {
     import scalatags.JsDom.all._
     import scalatags.JsDom.tags2
 
@@ -72,12 +73,12 @@ class UdashPagination[PageType : ModelValue, ElemType <: Property[PageType]] pri
   }
 }
 
-class UdashPager[PageType, ElemType <: Property[PageType]] private[pagination](aligned: Boolean, override val componentId: ComponentId)
-                (val pages: seq.SeqProperty[PageType, ElemType], val selectedPage: Property[Int])
+class UdashPager[PageType, ElemType <: ReadableProperty[PageType]] private[pagination](aligned: Boolean, override val componentId: ComponentId)
+                (val pages: seq.ReadableSeqProperty[PageType, ElemType], val selectedPage: Property[Int])
                 (itemFactory: (ElemType, UdashPagination.ButtonType) => dom.Element) extends PaginationComponent[PageType, ElemType] {
   import io.udash.css.CssView._
 
-  override lazy val render: dom.Element = {
+  override val render: dom.Element = {
     import scalatags.JsDom.all._
     import scalatags.JsDom.tags2
 
@@ -148,10 +149,10 @@ object UdashPagination {
     * @tparam ElemType Type of the property containing every element in `items` sequence.
     * @return `UdashPagination` component, call render to create DOM element.
     */
-  def apply[PageType : ModelValue, ElemType <: Property[PageType]]
-           (size: PaginationSize = PaginationSize.Default, showArrows: Property[Boolean] = Property(true),
-            highlightActive: Property[Boolean] = Property(true), componentId: ComponentId = UdashBootstrap.newId())
-           (pages: seq.SeqProperty[PageType, ElemType], selectedPage: Property[Int])
+  def apply[PageType : ModelValue, ElemType <: ReadableProperty[PageType]]
+           (size: PaginationSize = PaginationSize.Default, showArrows: ReadableProperty[Boolean] = Property(true),
+            highlightActive: ReadableProperty[Boolean] = Property(true), componentId: ComponentId = UdashBootstrap.newId())
+           (pages: seq.ReadableSeqProperty[PageType, ElemType], selectedPage: Property[Int])
            (itemFactory: (ElemType, UdashPagination.ButtonType) => dom.Element)(implicit ec: ExecutionContext): UdashPagination[PageType, ElemType] =
     new UdashPagination(size, showArrows, highlightActive, componentId)(pages, selectedPage)(itemFactory)
 
@@ -167,9 +168,9 @@ object UdashPagination {
     * @tparam ElemType Type of the property containing every element in `items` sequence.
     * @return `UdashPagination` component, call render to create DOM element.
     */
-  def pager[PageType, ElemType <: Property[PageType]]
+  def pager[PageType, ElemType <: ReadableProperty[PageType]]
            (aligned: Boolean = false, componentId: ComponentId = UdashBootstrap.newId())
-           (pages: seq.SeqProperty[PageType, ElemType], selectedPage: Property[Int])
+           (pages: seq.ReadableSeqProperty[PageType, ElemType], selectedPage: Property[Int])
            (itemFactory: (ElemType, UdashPagination.ButtonType) => dom.Element)(implicit ec: ExecutionContext): UdashPager[PageType, ElemType] =
     new UdashPager(aligned, componentId)(pages, selectedPage)(itemFactory)
 }

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/pagination/UdashPagination.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/pagination/UdashPagination.scala
@@ -30,12 +30,13 @@ sealed trait PaginationComponent[PageType, ElemType <: ReadableProperty[PageType
   def previous(): Unit = changePage(selectedPage.get - 1)
 }
 
-class UdashPagination[PageType : ModelValue, ElemType <: ReadableProperty[PageType]] private
-                     (size: PaginationSize, showArrows: ReadableProperty[Boolean],
-                      highlightActive: ReadableProperty[Boolean], override val componentId: ComponentId)
-                     (val pages: seq.ReadableSeqProperty[PageType, ElemType], val selectedPage: Property[Int])
-                     (itemFactory: (ElemType, UdashPagination.ButtonType) => dom.Element)(implicit ec: ExecutionContext)
+final class UdashPagination[PageType : ModelValue, ElemType <: ReadableProperty[PageType]] private
+                           (size: PaginationSize, showArrows: ReadableProperty[Boolean],
+                            highlightActive: ReadableProperty[Boolean], override val componentId: ComponentId)
+                           (val pages: seq.ReadableSeqProperty[PageType, ElemType], val selectedPage: Property[Int])
+                           (itemFactory: (ElemType, UdashPagination.ButtonType) => dom.Element)(implicit ec: ExecutionContext)
   extends PaginationComponent[PageType, ElemType] {
+
   import io.udash.css.CssView._
 
   override val render: dom.Element = {
@@ -73,9 +74,12 @@ class UdashPagination[PageType : ModelValue, ElemType <: ReadableProperty[PageTy
   }
 }
 
-class UdashPager[PageType, ElemType <: ReadableProperty[PageType]] private[pagination](aligned: Boolean, override val componentId: ComponentId)
-                (val pages: seq.ReadableSeqProperty[PageType, ElemType], val selectedPage: Property[Int])
-                (itemFactory: (ElemType, UdashPagination.ButtonType) => dom.Element) extends PaginationComponent[PageType, ElemType] {
+final class UdashPager[PageType, ElemType <: ReadableProperty[PageType]] private[pagination]
+                      (aligned: Boolean, override val componentId: ComponentId)
+                      (val pages: seq.ReadableSeqProperty[PageType, ElemType], val selectedPage: Property[Int])
+                      (itemFactory: (ElemType, UdashPagination.ButtonType) => dom.Element)
+  extends PaginationComponent[PageType, ElemType] {
+
   import io.udash.css.CssView._
 
   override val render: dom.Element = {

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/panel/UdashPanel.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/panel/UdashPanel.scala
@@ -8,7 +8,7 @@ import scalatags.JsDom.all._
 
 class UdashPanel private(panelStyle: PanelStyle, override val componentId: ComponentId)(content: Modifier*) extends UdashBootstrapComponent {
   import io.udash.css.CssView._
-  override lazy val render: dom.Element =
+  override val render: dom.Element =
     div(id := componentId, BootstrapStyles.Panel.panel, panelStyle)(
       content
     ).render

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/panel/UdashPanel.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/panel/UdashPanel.scala
@@ -6,8 +6,11 @@ import org.scalajs.dom
 
 import scalatags.JsDom.all._
 
-class UdashPanel private(panelStyle: PanelStyle, override val componentId: ComponentId)(content: Modifier*) extends UdashBootstrapComponent {
+final class UdashPanel private(panelStyle: PanelStyle, override val componentId: ComponentId)(content: Modifier*)
+  extends UdashBootstrapComponent {
+
   import io.udash.css.CssView._
+
   override val render: dom.Element =
     div(id := componentId, BootstrapStyles.Panel.panel, panelStyle)(
       content

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/progressbar/UdashProgressBar.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/progressbar/UdashProgressBar.scala
@@ -11,9 +11,9 @@ import org.scalajs.dom.Element
 import scala.concurrent.ExecutionContext
 import scalatags.JsDom.all._
 
-class UdashProgressBar private[progressbar](val progress: Property[Int], val showPercentage: Property[Boolean], barStyle: ProgressBarStyle,
-                                            minValue: Int, maxValue: Int, minWidthEm: Int, valueStringifier: ValueStringifier,
-                                            override val componentId: ComponentId)
+class UdashProgressBar private[progressbar](val progress: ReadableProperty[Int], val showPercentage: ReadableProperty[Boolean],
+                                            barStyle: ProgressBarStyle, minValue: Int, maxValue: Int, minWidthEm: Int,
+                                            valueStringifier: ValueStringifier, override val componentId: ComponentId)
                                            (implicit ec: ExecutionContext) extends UdashBootstrapComponent {
   import io.udash.css.CssView._
 
@@ -23,24 +23,22 @@ class UdashProgressBar private[progressbar](val progress: Property[Int], val sho
     aria.valuemin := minValue, aria.valuemax := maxValue, minWidth := s"${minWidthEm}em"
   )
 
-  lazy val stringifiedValue: ReadableProperty[String] = progress.transform(valueStringifier)
-
-  override lazy val render: Element =
+  override val render: Element = {
+    val stringifiedValue: ReadableProperty[String] = progress.transform(valueStringifier)
     div(BootstrapStyles.ProgressBar.progress)(
       div(id := componentId, modifiers)(
-      produce(showPercentage)(shouldShow =>
-        (
-          if (shouldShow) div(bind(stringifiedValue))
-          else span(BootstrapStyles.Visibility.srOnly)(bind(stringifiedValue))
-        ).render
+        produce(showPercentage) { shouldShow =>
+          if (shouldShow) div(bind(stringifiedValue)).render
+          else span(BootstrapStyles.Visibility.srOnly)(bind(stringifiedValue)).render
+        }
       )
-    )
-  ).render
+    ).render
+  }
 
 }
 
-class AnimatedUdashProgressBar private[progressbar](progress: Property[Int], showPercentage: Property[Boolean],
-                                                    val animate: Property[Boolean], barStyle: ProgressBarStyle,
+class AnimatedUdashProgressBar private[progressbar](progress: ReadableProperty[Int], showPercentage: ReadableProperty[Boolean],
+                                                    animate: ReadableProperty[Boolean], barStyle: ProgressBarStyle,
                                                     minValue: Int, maxValue: Int, minWidthEm: Int, valueStringifier: ValueStringifier,
                                                     override val componentId: ComponentId)
                                                    (implicit ec: ExecutionContext)
@@ -48,7 +46,7 @@ class AnimatedUdashProgressBar private[progressbar](progress: Property[Int], sho
 
   import io.udash.css.CssView._
 
-  override protected lazy val modifiers: Seq[Modifier] =
+  override protected def modifiers: Seq[Modifier] =
     super.modifiers ++ Seq(BootstrapStyles.active.styleIf(animate), ProgressBarStyle.Striped)
 }
 
@@ -76,7 +74,7 @@ object UdashProgressBar {
     * @param valueStringifier Converts progress to string displayed inside component.
     * @return `UdashProgressBar` component, call render to create DOM element.
     */
-  def apply(progress: Property[Int] = Property(0), showPercentage: Property[Boolean] = Property(true),
+  def apply(progress: ReadableProperty[Int] = Property(0), showPercentage: ReadableProperty[Boolean] = Property(true),
             barStyle: ProgressBarStyle = Default, minValue: Int = 0, maxValue: Int = 100, minWidth: Int = 2,
             componentId: ComponentId = UdashBootstrap.newId())
            (valueStringifier: ValueStringifier = percentValueStringifier(minValue, maxValue))(implicit ec: ExecutionContext): UdashProgressBar =
@@ -97,9 +95,9 @@ object UdashProgressBar {
     * @param valueStringifier Converts progress to string displayed inside component.
     * @return `UdashProgressBar` component, call render to create DOM element.
     */
-  def animated(progress: Property[Int] = Property(0), showPercentage: Property[Boolean] = Property(true), animate: Property[Boolean] = Property(true),
-               barStyle: ProgressBarStyle = Default, minValue: Int = 0, maxValue: Int = 100, minWidth: Int = 2,
-               componentId: ComponentId = UdashBootstrap.newId())
+  def animated(progress: ReadableProperty[Int] = Property(0), showPercentage: ReadableProperty[Boolean] = Property(true),
+               animate: ReadableProperty[Boolean] = Property(true), barStyle: ProgressBarStyle = Default, minValue: Int = 0,
+               maxValue: Int = 100, minWidth: Int = 2, componentId: ComponentId = UdashBootstrap.newId())
               (valueStringifier: ValueStringifier = percentValueStringifier(minValue, maxValue))(implicit ec: ExecutionContext): AnimatedUdashProgressBar =
     new AnimatedUdashProgressBar(progress, showPercentage, animate, barStyle, minValue, maxValue, minWidth, valueStringifier, componentId)
 

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/progressbar/UdashProgressBar.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/progressbar/UdashProgressBar.scala
@@ -11,10 +11,15 @@ import org.scalajs.dom.Element
 import scala.concurrent.ExecutionContext
 import scalatags.JsDom.all._
 
-class UdashProgressBar private[progressbar](val progress: ReadableProperty[Int], val showPercentage: ReadableProperty[Boolean],
-                                            barStyle: ProgressBarStyle, minValue: Int, maxValue: Int, minWidthEm: Int,
-                                            valueStringifier: ValueStringifier, override val componentId: ComponentId)
-                                           (implicit ec: ExecutionContext) extends UdashBootstrapComponent {
+sealed abstract class UdashProgressBarBase private[progressbar](val progress: ReadableProperty[Int],
+                                                                val showPercentage: ReadableProperty[Boolean],
+                                                                barStyle: ProgressBarStyle, minValue: Int,
+                                                                maxValue: Int, minWidthEm: Int,
+                                                                valueStringifier: ValueStringifier,
+                                                                override val componentId: ComponentId)
+                                                               (implicit ec: ExecutionContext)
+  extends UdashBootstrapComponent {
+
   import io.udash.css.CssView._
 
   protected def modifiers = Seq(
@@ -23,7 +28,7 @@ class UdashProgressBar private[progressbar](val progress: ReadableProperty[Int],
     aria.valuemin := minValue, aria.valuemax := maxValue, minWidth := s"${minWidthEm}em"
   )
 
-  override val render: Element = {
+  override final val render: Element = {
     val stringifiedValue: ReadableProperty[String] = progress.transform(valueStringifier)
     div(BootstrapStyles.ProgressBar.progress)(
       div(id := componentId, modifiers)(
@@ -37,12 +42,18 @@ class UdashProgressBar private[progressbar](val progress: ReadableProperty[Int],
 
 }
 
-class AnimatedUdashProgressBar private[progressbar](progress: ReadableProperty[Int], showPercentage: ReadableProperty[Boolean],
-                                                    animate: ReadableProperty[Boolean], barStyle: ProgressBarStyle,
-                                                    minValue: Int, maxValue: Int, minWidthEm: Int, valueStringifier: ValueStringifier,
-                                                    override val componentId: ComponentId)
-                                                   (implicit ec: ExecutionContext)
-  extends UdashProgressBar(progress, showPercentage, barStyle, minValue, maxValue, minWidthEm, valueStringifier, componentId) {
+final class UdashProgressBar private[progressbar](progress: ReadableProperty[Int], showPercentage: ReadableProperty[Boolean],
+                                                  barStyle: ProgressBarStyle, minValue: Int, maxValue: Int, minWidthEm: Int,
+                                                  valueStringifier: ValueStringifier, override val componentId: ComponentId)
+                                                 (implicit ec: ExecutionContext)
+  extends UdashProgressBarBase(progress, showPercentage, barStyle, minValue, maxValue, minWidthEm, valueStringifier, componentId)
+
+final class AnimatedUdashProgressBar private[progressbar](progress: ReadableProperty[Int], showPercentage: ReadableProperty[Boolean],
+                                                          animate: ReadableProperty[Boolean], barStyle: ProgressBarStyle,
+                                                          minValue: Int, maxValue: Int, minWidthEm: Int,
+                                                          valueStringifier: ValueStringifier, override val componentId: ComponentId)
+                                                         (implicit ec: ExecutionContext)
+  extends UdashProgressBarBase(progress, showPercentage, barStyle, minValue, maxValue, minWidthEm, valueStringifier, componentId) {
 
   import io.udash.css.CssView._
 

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/table/UdashTable.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/table/UdashTable.scala
@@ -7,15 +7,15 @@ import io.udash.properties.seq
 import org.scalajs.dom
 import org.scalajs.dom._
 
-class UdashTable[ItemType, ElemType <: Property[ItemType]] private
-                (striped: Property[Boolean], bordered: Property[Boolean], hover: Property[Boolean],
-                 condensed: Property[Boolean], override val componentId: ComponentId)
-                (val items: seq.SeqProperty[ItemType, ElemType])
+class UdashTable[ItemType, ElemType <: ReadableProperty[ItemType]] private
+                (striped: ReadableProperty[Boolean], bordered: ReadableProperty[Boolean], hover: ReadableProperty[Boolean],
+                 condensed: ReadableProperty[Boolean], override val componentId: ComponentId)
+                (val items: seq.ReadableSeqProperty[ItemType, ElemType])
                 (headerFactory: Option[() => dom.Element],
                  rowFactory: (ElemType) => dom.Element) extends UdashBootstrapComponent {
   import io.udash.css.CssView._
 
-  override lazy val render: Element = {
+  override val render: Element = {
     import scalatags.JsDom.all._
 
     table(
@@ -55,11 +55,11 @@ object UdashTable {
     * @tparam ElemType Type of the property containing every element in `items` sequence.
     * @return `UdashTable` component, call render to create DOM element.
     */
-  def apply[ItemType, ElemType <: Property[ItemType]]
-           (striped: Property[Boolean] = Property(false), bordered: Property[Boolean] = Property(false),
-            hover: Property[Boolean] = Property(false), condensed: Property[Boolean] = Property(false),
+  def apply[ItemType, ElemType <: ReadableProperty[ItemType]]
+           (striped: ReadableProperty[Boolean] = Property(false), bordered: ReadableProperty[Boolean] = Property(false),
+            hover: ReadableProperty[Boolean] = Property(false), condensed: ReadableProperty[Boolean] = Property(false),
             componentId: ComponentId = UdashBootstrap.newId())
-           (items: seq.SeqProperty[ItemType, ElemType])
+           (items: seq.ReadableSeqProperty[ItemType, ElemType])
            (rowFactory: (ElemType) => dom.Element,
             headerFactory: Option[() => dom.Element] = None): UdashTable[ItemType, ElemType] =
     new UdashTable(striped, bordered, hover, condensed, componentId)(items)(headerFactory, rowFactory)

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/table/UdashTable.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/table/UdashTable.scala
@@ -7,12 +7,14 @@ import io.udash.properties.seq
 import org.scalajs.dom
 import org.scalajs.dom._
 
-class UdashTable[ItemType, ElemType <: ReadableProperty[ItemType]] private
-                (striped: ReadableProperty[Boolean], bordered: ReadableProperty[Boolean], hover: ReadableProperty[Boolean],
-                 condensed: ReadableProperty[Boolean], override val componentId: ComponentId)
-                (val items: seq.ReadableSeqProperty[ItemType, ElemType])
-                (headerFactory: Option[() => dom.Element],
-                 rowFactory: (ElemType) => dom.Element) extends UdashBootstrapComponent {
+final class UdashTable[ItemType, ElemType <: ReadableProperty[ItemType]] private
+                      (striped: ReadableProperty[Boolean], bordered: ReadableProperty[Boolean], hover: ReadableProperty[Boolean],
+                       condensed: ReadableProperty[Boolean], override val componentId: ComponentId)
+                      (val items: seq.ReadableSeqProperty[ItemType, ElemType])
+                      (headerFactory: Option[() => dom.Element],
+                       rowFactory: (ElemType) => dom.Element)
+  extends UdashBootstrapComponent {
+
   import io.udash.css.CssView._
 
   override val render: Element = {

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/tooltip/UdashPopover.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/tooltip/UdashPopover.scala
@@ -7,7 +7,9 @@ import org.scalajs.dom
 import scala.language.postfixOps
 import scala.scalajs.js
 
-class UdashPopover(selector: UdashPopover.UdashPopoverJQuery) extends Listenable[UdashPopover, UdashPopover.TooltipEvent] {
+final class UdashPopover(selector: UdashPopover.UdashPopoverJQuery)
+  extends Listenable[UdashPopover, UdashPopover.TooltipEvent] {
+
   /** Shows popover. */
   def show(): Unit =
     selector.popover("show")

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/tooltip/UdashTooltip.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/tooltip/UdashTooltip.scala
@@ -7,7 +7,8 @@ import org.scalajs.dom
 import scala.language.postfixOps
 import scala.scalajs.js
 
-class UdashTooltip private(selector: UdashTooltip.UdashTooltipJQuery) extends Listenable[UdashTooltip, UdashTooltip.TooltipEvent] {
+final class UdashTooltip private(selector: UdashTooltip.UdashTooltipJQuery)
+  extends Listenable[UdashTooltip, UdashTooltip.TooltipEvent] {
   /** Shows the tooltip. */
   def show(): Unit =
     selector.tooltip("show")

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/utils/UdashBadge.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/utils/UdashBadge.scala
@@ -7,9 +7,9 @@ import org.scalajs.dom
 
 import scalatags.JsDom.all._
 
-class UdashBadge private(override val componentId: ComponentId)(mds: Modifier*) extends UdashBootstrapComponent {
+final class UdashBadge private(override val componentId: ComponentId)(mds: Modifier*) extends UdashBootstrapComponent {
   import io.udash.css.CssView._
-  override lazy val render: dom.Element =
+  override val render: dom.Element =
     span(id := componentId, BootstrapStyles.Label.badge)(mds).render
 }
 

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/utils/UdashBadge.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/utils/UdashBadge.scala
@@ -22,7 +22,7 @@ object UdashBadge {
     * @param componentId Id of the root DOM node.
     * @return `UdashBadge` component, call render to create DOM element.
     */
-  def apply(content: Property[_], componentId: ComponentId = UdashBootstrap.newId()): UdashBadge =
+  def apply(content: ReadableProperty[_], componentId: ComponentId = UdashBootstrap.newId()): UdashBadge =
     new UdashBadge(componentId)(bind(content))
 
   /**

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/utils/UdashBreadcrumbs.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/utils/UdashBreadcrumbs.scala
@@ -10,11 +10,14 @@ import org.scalajs.dom.html.Anchor
 
 import scala.concurrent.ExecutionContext
 
-class UdashBreadcrumbs[ItemType, ElemType <: ReadableProperty[ItemType]] private
-                      (val pages: seq.ReadableSeqProperty[ItemType, ElemType], override val componentId: ComponentId)
-                      (itemFactory: (ElemType) => dom.Element, isSelected: (ItemType) => Boolean)
-                      (implicit ec: ExecutionContext) extends UdashBootstrapComponent {
+final class UdashBreadcrumbs[ItemType, ElemType <: ReadableProperty[ItemType]] private
+                            (val pages: seq.ReadableSeqProperty[ItemType, ElemType], override val componentId: ComponentId)
+                            (itemFactory: (ElemType) => dom.Element, isSelected: (ItemType) => Boolean)
+                            (implicit ec: ExecutionContext)
+  extends UdashBootstrapComponent {
+
   import io.udash.css.CssView._
+
   override val render: Element = {
     import scalatags.JsDom.all._
     ol(id := componentId, BootstrapStyles.Navigation.breadcrumb)(

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/utils/UdashBreadcrumbs.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/utils/UdashBreadcrumbs.scala
@@ -10,12 +10,12 @@ import org.scalajs.dom.html.Anchor
 
 import scala.concurrent.ExecutionContext
 
-class UdashBreadcrumbs[ItemType, ElemType <: Property[ItemType]] private
-                      (val pages: seq.SeqProperty[ItemType, ElemType], override val componentId: ComponentId)
-                      (itemFactory: (ElemType) => dom.Element,
-                       isSelected: (ItemType) => Boolean)(implicit ec: ExecutionContext) extends UdashBootstrapComponent {
+class UdashBreadcrumbs[ItemType, ElemType <: ReadableProperty[ItemType]] private
+                      (val pages: seq.ReadableSeqProperty[ItemType, ElemType], override val componentId: ComponentId)
+                      (itemFactory: (ElemType) => dom.Element, isSelected: (ItemType) => Boolean)
+                      (implicit ec: ExecutionContext) extends UdashBootstrapComponent {
   import io.udash.css.CssView._
-  override lazy val render: Element = {
+  override val render: Element = {
     import scalatags.JsDom.all._
     ol(id := componentId, BootstrapStyles.Navigation.breadcrumb)(
       repeat(pages)(page => {
@@ -62,9 +62,9 @@ object UdashBreadcrumbs {
     * @tparam ElemType Type of the property containing every element in `items` sequence.
     * @return `UdashBreadcrumbs` component, call render to create DOM element.
     */
-  def apply[ItemType, ElemType <: Property[ItemType]]
-           (pages: seq.SeqProperty[ItemType, ElemType], componentId: ComponentId = UdashBootstrap.newId())
-           (itemFactory: (ElemType) => dom.Element,
-            isSelected: (ItemType) => Boolean = (_: ItemType) => false)(implicit ec: ExecutionContext): UdashBreadcrumbs[ItemType, ElemType] =
+  def apply[ItemType, ElemType <: ReadableProperty[ItemType]]
+           (pages: seq.ReadableSeqProperty[ItemType, ElemType], componentId: ComponentId = UdashBootstrap.newId())
+           (itemFactory: (ElemType) => dom.Element, isSelected: (ItemType) => Boolean = (_: ItemType) => false)
+           (implicit ec: ExecutionContext): UdashBreadcrumbs[ItemType, ElemType] =
     new UdashBreadcrumbs(pages, componentId)(itemFactory, isSelected)
 }

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/utils/UdashJumbotron.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/utils/UdashJumbotron.scala
@@ -7,8 +7,11 @@ import org.scalajs.dom
 
 import scalatags.JsDom.all._
 
-class UdashJumbotron private(override val componentId: ComponentId)(mds: Modifier*) extends UdashBootstrapComponent {
+final class UdashJumbotron private(override val componentId: ComponentId)(mds: Modifier*)
+  extends UdashBootstrapComponent {
+
   import io.udash.css.CssView._
+
   override val render: dom.Element =
     div(id := componentId, BootstrapStyles.jumbotron)(mds).render
 }

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/utils/UdashJumbotron.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/utils/UdashJumbotron.scala
@@ -9,7 +9,7 @@ import scalatags.JsDom.all._
 
 class UdashJumbotron private(override val componentId: ComponentId)(mds: Modifier*) extends UdashBootstrapComponent {
   import io.udash.css.CssView._
-  override lazy val render: dom.Element =
+  override val render: dom.Element =
     div(id := componentId, BootstrapStyles.jumbotron)(mds).render
 }
 
@@ -22,7 +22,7 @@ object UdashJumbotron {
     * @param componentId Id of the root DOM node.
     * @return `UdashJumbotron` component, call render to create DOM element.
     */
-  def apply(content: Property[_], componentId: ComponentId = UdashBootstrap.newId()): UdashJumbotron =
+  def apply(content: ReadableProperty[_], componentId: ComponentId = UdashBootstrap.newId()): UdashJumbotron =
     new UdashJumbotron(componentId)(bind(content))
 
   /**

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/utils/UdashListGroup.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/utils/UdashListGroup.scala
@@ -7,9 +7,11 @@ import io.udash.properties.seq
 import org.scalajs.dom
 import org.scalajs.dom.Element
 
-class UdashListGroup[ItemType, ElemType <: ReadableProperty[ItemType]] private
-                    (items: seq.ReadableSeqProperty[ItemType, ElemType], override val componentId: ComponentId)
-                    (body: (ElemType) => dom.Element) extends UdashBootstrapComponent {
+final class UdashListGroup[ItemType, ElemType <: ReadableProperty[ItemType]] private
+                          (items: seq.ReadableSeqProperty[ItemType, ElemType], override val componentId: ComponentId)
+                          (body: (ElemType) => dom.Element)
+  extends UdashBootstrapComponent {
+
   import scalatags.JsDom.all._
   import io.udash.css.CssView._
 

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/utils/UdashListGroup.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/utils/UdashListGroup.scala
@@ -3,16 +3,17 @@ package utils
 
 import io.udash._
 import io.udash.bootstrap.UdashBootstrap.ComponentId
-import io.udash.properties.seq.SeqProperty
+import io.udash.properties.seq
 import org.scalajs.dom
 import org.scalajs.dom.Element
 
-class UdashListGroup[ItemType, ElemType <: Property[ItemType]] private(items: SeqProperty[ItemType, ElemType], override val componentId: ComponentId)
-                                                                      (body: (ElemType) => dom.Element) extends UdashBootstrapComponent {
+class UdashListGroup[ItemType, ElemType <: ReadableProperty[ItemType]] private
+                    (items: seq.ReadableSeqProperty[ItemType, ElemType], override val componentId: ComponentId)
+                    (body: (ElemType) => dom.Element) extends UdashBootstrapComponent {
   import scalatags.JsDom.all._
   import io.udash.css.CssView._
 
-  override lazy val render: Element =
+  override val render: Element =
     ul(id := componentId, BootstrapStyles.List.listGroup)(
       repeat(items)(item => {
         val el = body(item)
@@ -34,8 +35,8 @@ object UdashListGroup {
     * @tparam ElemType Type of the property containing every element in `items` sequence.
     * @return `UdashBreadcrumbs` component, call render to create DOM element.
     */
-  def apply[ItemType, ElemType <: Property[ItemType]]
-           (items: SeqProperty[ItemType, ElemType], componentId: ComponentId = UdashBootstrap.newId())
+  def apply[ItemType, ElemType <: ReadableProperty[ItemType]]
+           (items: seq.ReadableSeqProperty[ItemType, ElemType], componentId: ComponentId = UdashBootstrap.newId())
            (body: (ElemType) => Element): UdashListGroup[ItemType, ElemType] =
     new UdashListGroup(items, componentId)(body)
 }

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/utils/UdashPageHeader.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/utils/UdashPageHeader.scala
@@ -9,7 +9,7 @@ import scalatags.JsDom.all._
 
 class UdashPageHeader private(override val componentId: ComponentId, mds: Modifier*) extends UdashBootstrapComponent {
   import io.udash.css.CssView._
-  override lazy val render: dom.Element =
+  override val render: dom.Element =
     span(id := componentId, BootstrapStyles.Typography.pageHeader)(mds).render
 }
 
@@ -22,7 +22,7 @@ object UdashPageHeader {
     * @param componentId Id of the root DOM node.
     * @return `UdashPageHeader` component, call render to create DOM element.
     */
-  def apply(content: Property[_], componentId: ComponentId = UdashBootstrap.newId()): UdashPageHeader =
+  def apply(content: ReadableProperty[_], componentId: ComponentId = UdashBootstrap.newId()): UdashPageHeader =
     new UdashPageHeader(componentId, bind(content))
 
   /**

--- a/bootstrap/frontend/src/main/scala/io/udash/bootstrap/utils/UdashPageHeader.scala
+++ b/bootstrap/frontend/src/main/scala/io/udash/bootstrap/utils/UdashPageHeader.scala
@@ -7,8 +7,11 @@ import org.scalajs.dom
 
 import scalatags.JsDom.all._
 
-class UdashPageHeader private(override val componentId: ComponentId, mds: Modifier*) extends UdashBootstrapComponent {
+final class UdashPageHeader private(override val componentId: ComponentId, mds: Modifier*)
+  extends UdashBootstrapComponent {
+
   import io.udash.css.CssView._
+
   override val render: dom.Element =
     span(id := componentId, BootstrapStyles.Typography.pageHeader)(mds).render
 }

--- a/core/frontend/src/main/scala/io/udash/bindings/FileInput.scala
+++ b/core/frontend/src/main/scala/io/udash/bindings/FileInput.scala
@@ -18,7 +18,7 @@ object FileInput {
     * @param selectedFiles This property contains information about files selected by user.
     * @return
     */
-  def apply(inputName: String, acceptMultipleFiles: Property[Boolean], selectedFiles: SeqProperty[File])
+  def apply(inputName: String, acceptMultipleFiles: ReadableProperty[Boolean], selectedFiles: SeqProperty[File])
            (inputMds: Modifier[dom.Element]*): html.Input = {
     import scalatags.JsDom.all._
     val inp = input(


### PR DESCRIPTION
* Property -> ReadableProperty (closes #102)
* Removed `lazy` from DOM content of components
* Skip empty label in UdashForm
* ButtonClickEvent contains MouseEvent