### PR TITLE
DOM bindings - handling nested bindings clean up

### DIFF
--- a/core/frontend/src/main/scala/io/udash/bindings/modifiers/AttrModifier.scala
+++ b/core/frontend/src/main/scala/io/udash/bindings/modifiers/AttrModifier.scala
@@ -1,18 +1,14 @@
 package io.udash.bindings.modifiers
 
-import io.udash.bindings._
-import io.udash.properties._
 import io.udash.properties.single.ReadableProperty
-import org.scalajs.dom
 import org.scalajs.dom._
 
-import scalatags.generic._
-
-private[bindings] class AttrModifier[T](property: ReadableProperty[T], updater: ((T, Element) => Any)) extends Modifier[dom.Element] with Bindings {
+private[bindings]
+class AttrModifier[T](property: ReadableProperty[T], updater: ((T, Element) => Any)) extends Binding {
   override def applyTo(element: Element): Unit = {
     def rebuild() = updater(property.get, element)
 
-    property.listen(_ => rebuild())
+    propertyListeners += property.listen(_ => rebuild())
     rebuild()
   }
 }

--- a/core/frontend/src/main/scala/io/udash/bindings/modifiers/Binding.scala
+++ b/core/frontend/src/main/scala/io/udash/bindings/modifiers/Binding.scala
@@ -1,0 +1,30 @@
+package io.udash.bindings.modifiers
+
+import com.avsystem.commons.SharedExtensions._
+import io.udash.utils.Registration
+import org.scalajs.dom
+
+import scala.scalajs.js
+import scalatags.generic.Modifier
+
+/** Modifier representing data binding. */
+trait Binding extends Modifier[dom.Element] {
+  protected var propertyListeners: js.Array[Registration] = js.Array()
+  protected var nestedBindings: js.Array[Binding] = js.Array()
+
+  protected def nestedInterceptor(binding: Binding): Binding =
+    binding.setup { nestedBindings += _ }
+
+  /** This method clears all bindings and listeners. */
+  def kill(): Unit = {
+    killNestedBindings()
+    propertyListeners.foreach(_.cancel())
+    propertyListeners.length = 0 // JS way to clear an array
+  }
+
+  /** This method clears all nested bindings and listeners. */
+  def killNestedBindings(): Unit = {
+    nestedBindings.foreach(_.kill())
+    nestedBindings.length = 0 // JS way to clear an array
+  }
+}

--- a/core/frontend/src/main/scala/io/udash/bindings/modifiers/Binding.scala
+++ b/core/frontend/src/main/scala/io/udash/bindings/modifiers/Binding.scala
@@ -9,8 +9,8 @@ import scalatags.generic.Modifier
 
 /** Modifier representing data binding. */
 trait Binding extends Modifier[dom.Element] {
-  protected var propertyListeners: js.Array[Registration] = js.Array()
-  protected var nestedBindings: js.Array[Binding] = js.Array()
+  protected final val propertyListeners: js.Array[Registration] = js.Array()
+  protected final val nestedBindings: js.Array[Binding] = js.Array()
 
   protected def nestedInterceptor(binding: Binding): Binding =
     binding.setup { nestedBindings += _ }

--- a/core/frontend/src/main/scala/io/udash/bindings/modifiers/PropertyModifier.scala
+++ b/core/frontend/src/main/scala/io/udash/bindings/modifiers/PropertyModifier.scala
@@ -1,15 +1,22 @@
 package io.udash.bindings.modifiers
 
-import io.udash.properties._
 import io.udash.properties.single.ReadableProperty
 import io.udash.utils.Registration
 import org.scalajs.dom
-import org.scalajs.dom._
 
-private[bindings] class PropertyModifier[T](override val property: ReadableProperty[T],
-                                            override val builder: (T => Seq[dom.Element]),
-                                            override val checkNull: Boolean) extends ValueModifier[T] {
-  def listen(callback: T => Unit): Registration = property.listen(callback)
+private[bindings]
+class PropertyModifier[T](override val property: ReadableProperty[T],
+                          override val builder: ((T, Binding => Binding) => Seq[dom.Element]),
+                          override val checkNull: Boolean)
+  extends ValueModifier[T] {
+
+  def this(property: ReadableProperty[T], builder: (T => Seq[dom.Element]), checkNull: Boolean) = {
+    this(property, (data: T, _: Binding => Binding) => builder(data), checkNull)
+  }
+
+  def listen(callback: T => Unit): Registration =
+    property.listen(callback)
+
 }
 
 

--- a/core/frontend/src/main/scala/io/udash/bindings/modifiers/SeqAsValueModifier.scala
+++ b/core/frontend/src/main/scala/io/udash/bindings/modifiers/SeqAsValueModifier.scala
@@ -1,16 +1,24 @@
 package io.udash.bindings.modifiers
 
-import io.udash.properties._
 import io.udash.properties.seq.ReadableSeqProperty
 import io.udash.properties.single.ReadableProperty
 import io.udash.utils.Registration
 import org.scalajs.dom
-import org.scalajs.dom._
 
-private[bindings] class SeqAsValueModifier[T](override val property: ReadableSeqProperty[T, _ <: ReadableProperty[T]],
-                                              override val builder: Seq[T] => Seq[dom.Element]) extends ValueModifier[Seq[T]] {
-  override def listen(callback: Seq[T] => Unit): Registration = property.listen(callback)
+private[bindings]
+class SeqAsValueModifier[T](override val property: ReadableSeqProperty[T, _ <: ReadableProperty[T]],
+                            override val builder: (Seq[T], Binding => Binding) => Seq[dom.Element])
+  extends ValueModifier[Seq[T]] {
+
+  def this(property: ReadableSeqProperty[T, _ <: ReadableProperty[T]], builder: Seq[T] => Seq[dom.Element]) = {
+    this(property, (data: Seq[T], _: Binding => Binding) => builder(data))
+  }
+
+  override def listen(callback: Seq[T] => Unit): Registration =
+    property.listen(callback)
+
   override def checkNull: Boolean = false // SeqProperty can not return null from `get` method
+
 }
 
 

--- a/core/frontend/src/main/scala/io/udash/bindings/modifiers/SeqAsValuePatchingModifier.scala
+++ b/core/frontend/src/main/scala/io/udash/bindings/modifiers/SeqAsValuePatchingModifier.scala
@@ -3,23 +3,26 @@ package io.udash.bindings.modifiers
 import io.udash.properties._
 import io.udash.properties.seq.{Patch, ReadableSeqProperty}
 import io.udash.properties.single.ReadableProperty
-import org.scalajs.dom
 import org.scalajs.dom._
 
-import scalatags.generic._
+private[bindings]
+class SeqAsValuePatchingModifier[T, E <: ReadableProperty[T]]
+                                (property: ReadableSeqProperty[T, E],
+                                 initBuilder: (Seq[E], Binding => Binding) => Seq[Element],
+                                 elementsUpdater: (Patch[E], Seq[Element], Binding => Binding) => Any)
+  extends Binding {
 
-private[bindings] class SeqAsValuePatchingModifier[T, E <: ReadableProperty[T]]
-  (property: ReadableSeqProperty[T, E],
-   initBuilder: Seq[E] => Seq[Element],
-   elementsUpdater: (Patch[E], Seq[Element]) => Any) extends Modifier[dom.Element] {
+  def this(property: ReadableSeqProperty[T, E], initBuilder: Seq[E] => Seq[Element], elementsUpdater: (Patch[E], Seq[Element]) => Any) = {
+    this(property, (s, _) => initBuilder(s), (s, el, _) => elementsUpdater(s, el))
+  }
 
-  override def applyTo(t: dom.Element): Unit = {
-    val elements: Seq[Element] = initBuilder.apply(property.elemProperties)
+  override def applyTo(t: Element): Unit = {
+    val elements: Seq[Element] = initBuilder(property.elemProperties, nestedInterceptor)
     elements.foreach(t.appendChild)
 
-    CallbackSequencer.finalCallback(() => {
-      property.listenStructure(patch => elementsUpdater(patch, elements))
-    })
+    CallbackSequencer.finalCallback { () =>
+      propertyListeners += property.listenStructure(patch => elementsUpdater(patch, elements, nestedInterceptor))
+    }
   }
 }
 

--- a/core/frontend/src/main/scala/io/udash/bindings/modifiers/SimplePropertyModifier.scala
+++ b/core/frontend/src/main/scala/io/udash/bindings/modifiers/SimplePropertyModifier.scala
@@ -6,10 +6,16 @@ import org.scalajs.dom
 
 import scalatags.JsDom
 
-private[bindings] class SimplePropertyModifier[T](property: ReadableProperty[T], checkNull: Boolean) extends PropertyModifier[T](property, (t: T) => {
-  if (t != null) JsDom.StringFrag(t.toString).render.asInstanceOf[dom.Element]
-  else emptyStringNode()
-}, checkNull)
+private[bindings]
+class SimplePropertyModifier[T](property: ReadableProperty[T], checkNull: Boolean)
+  extends PropertyModifier[T](
+    property,
+    (t: T) => {
+      if (t != null) JsDom.StringFrag(t.toString).render.asInstanceOf[dom.Element]
+      else emptyStringNode()
+    },
+    checkNull
+  )
 
 
 

--- a/core/frontend/src/main/scala/io/udash/bindings/modifiers/ValidationValueModifier.scala
+++ b/core/frontend/src/main/scala/io/udash/bindings/modifiers/ValidationValueModifier.scala
@@ -1,27 +1,36 @@
 package io.udash.bindings.modifiers
 
 import io.udash.StrictLogging
-import io.udash.bindings.Bindings
+import io.udash.bindings.Bindings._
 import io.udash.properties._
 import io.udash.properties.single.ReadableProperty
-import org.scalajs.dom
 import org.scalajs.dom._
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
-import scalatags.generic._
 
-private[bindings] class ValidationValueModifier[T](property: ReadableProperty[T],
-                                 initBuilder: Option[Future[ValidationResult] => Seq[Element]],
-                                 completeBuilder: ValidationResult => Seq[Element],
-                                 errorBuilder: Option[Throwable => Seq[Element]])(implicit ec: ExecutionContext) extends Modifier[dom.Element] with Bindings with StrictLogging {
+private[bindings]
+class ValidationValueModifier[T](property: ReadableProperty[T],
+                                 initBuilder: Option[(Future[ValidationResult], Binding => Binding) => Seq[Element]],
+                                 completeBuilder: (ValidationResult, Binding => Binding) => Seq[Element],
+                                 errorBuilder: Option[(Throwable, Binding => Binding) => Seq[Element]])
+                                (implicit ec: ExecutionContext)
+  extends Binding with StrictLogging {
 
-  override def applyTo(root: dom.Element): Unit = {
-    var elements: Seq[Element] = null
+  def this(property: ReadableProperty[T], initBuilder: Option[Future[ValidationResult] => Seq[Element]],
+           completeBuilder: ValidationResult => Seq[Element], errorBuilder: Option[Throwable => Seq[Element]])
+          (implicit ec: ExecutionContext) = {
+    this(property, initBuilder.map(c => (d, _) => c(d)), (d, _) => completeBuilder(d), errorBuilder.map(c => (d, _) => c(d)))
+  }
 
-    def rebuild[R](result: R, builder: R => Seq[Element]) = {
+  override def applyTo(root: Element): Unit = {
+    var elements: Seq[Element] = Seq.empty
+
+    def rebuild[R](result: R, builder: (R, Binding => Binding) => Seq[Element]) = {
+      killNestedBindings()
+
       val oldEls = elements
-      elements = builder.apply(result)
+      elements = builder.apply(result, nestedInterceptor)
       if (elements.isEmpty) elements = emptyStringNode()
       root.replaceChildren(oldEls, elements)
     }
@@ -33,14 +42,12 @@ private[bindings] class ValidationValueModifier[T](property: ReadableProperty[T]
         case Success(result) => rebuild(result, completeBuilder)
         case Failure(error) =>
           logger.error("Validation failed!")
-          error.printStackTrace()
-
           errorBuilder.foreach(b => rebuild(error, b))
       }
     }
 
     listener(property.get)
-    property.listen(listener)
+    propertyListeners += property.listen(listener)
   }
 }
 

--- a/core/frontend/src/main/scala/io/udash/bindings/modifiers/ValueModifier.scala
+++ b/core/frontend/src/main/scala/io/udash/bindings/modifiers/ValueModifier.scala
@@ -25,7 +25,7 @@ trait ValueModifier[T] extends Binding {
   override def applyTo(t: dom.Element): Unit = {
     var elements: Seq[Element] = Seq.empty
 
-    def rebuild(propertyValue: T) = {
+    def rebuild(propertyValue: T): Unit = {
       killNestedBindings()
 
       val oldEls = elements

--- a/core/frontend/src/main/scala/io/udash/bindings/modifiers/package.scala
+++ b/core/frontend/src/main/scala/io/udash/bindings/modifiers/package.scala
@@ -4,8 +4,8 @@ import org.scalajs.dom.Element
 
 package object modifiers {
   implicit class ElementExts(val el: Element) extends AnyVal {
-    def replaceChildren(oldChildren: Seq[Element], newChildren: Seq[Element]) = {
-      if (oldChildren == null) newChildren.foreach(el.appendChild)
+    def replaceChildren(oldChildren: Seq[Element], newChildren: Seq[Element]): Unit = {
+      if (oldChildren == null || oldChildren.isEmpty) newChildren.foreach(el.appendChild)
       else {
         oldChildren.zip(newChildren).foreach { case (old, fresh) => el.replaceChild(fresh, old) }
         oldChildren.drop(newChildren.size).foreach(el.removeChild)


### PR DESCRIPTION
## Problem

Sometimes you want to create property binding inside another binding builder. For example:
```scala
val p = Property("A")
val p2 = Property("a")
produce(p) { v =>
  div(v, bind(p2)).render
}
```
When you change `p` value, the builder creates new element with new binding inside, but unfortunately the old one is still working. There is no way to kill or reuse the old binding, so it will be working as long as you keep reference `p2`.

## Solution

The new variations of bindings (`*WithNested`) providing interceptor which prepares nested binding to be removed when it's no longer needed.  For example:
```scala
val p = Property("A")
val p2 = Property("a")
produceWithNested(p) { (v, nested) =>
  div(v, nested(bind(p2))).render
}
```