### PR TITLE
produce() calls the callback even when some properties are null

### DIFF
--- a/core/frontend/src/test/scala/io/udash/bindings/TagsBindingTest.scala
+++ b/core/frontend/src/test/scala/io/udash/bindings/TagsBindingTest.scala
@@ -464,6 +464,18 @@ class TagsBindingTest extends UdashFrontendTest with Bindings { bindings: Bindin
       template.childNodes.apply(0).textContent should be("")
     }
 
+    "handle null in case class sub-properties value providing empty span element" in {
+      case class Test(i: Int, subType: SubTest)
+      case class SubTest(i: Int)
+
+      val p = ModelProperty.empty[Test]
+      val template = div(produce(p) { t =>
+        div(t.subType.i).render
+      }).render
+
+      template.textContent should be("")
+    }
+
     "allow custom null handling" in {
       val p = Property[String]("ABC")
       val template = div(


### PR DESCRIPTION
This demonstrates the issue displayed in https://scalafiddle.io/sf/uPKEaxc/0

When you have a model property that itself contains sub-properties that are case classes, these are null on an empty model. `produce` does not check this before passing it to its callback.