### PR TITLE
Extract reusable trait for rawTo* methods

### DIFF
--- a/rest/backend/src/main/scala/io/udash/rest/server/DefaultExposesREST.scala
+++ b/rest/backend/src/main/scala/io/udash/rest/server/DefaultExposesREST.scala
@@ -1,21 +1,12 @@
 package io.udash.rest.server
 
-import io.udash.rest.DefaultRESTFramework
-import io.udash.rpc.serialization.URLEncoder
+import io.udash.rest.{DefaultRESTFramework, RESTConverters}
 
 class DefaultExposesREST[ServerRPCType : DefaultRESTFramework.ValidServerREST : DefaultRESTFramework.RPCMetadata](localRest: ServerRPCType)(
   implicit protected val localRpcAsRaw: DefaultRESTFramework.AsRawRPC[ServerRPCType]
-) extends ExposesREST[ServerRPCType](localRest) {
+) extends ExposesREST[ServerRPCType](localRest) with RESTConverters {
   override val framework = DefaultRESTFramework
 
   protected val rpcMetadata: DefaultRESTFramework.RPCMetadata[ServerRPCType] =
     implicitly[DefaultRESTFramework.RPCMetadata[ServerRPCType]]
-
-  override def headerArgumentToRaw(raw: String, isStringArg: Boolean): framework.RawValue = rawArg(raw, isStringArg)
-  override def queryArgumentToRaw(raw: String, isStringArg: Boolean): framework.RawValue = rawArg(raw, isStringArg)
-  override def urlPartToRaw(raw: String, isStringArg: Boolean): framework.RawValue = rawArg(URLEncoder.decode(raw), isStringArg)
-
-  private def rawArg(raw: String, isStringArg: Boolean): framework.RawValue =
-    if (isStringArg) framework.stringToRaw(s""""$raw"""")
-    else framework.stringToRaw(raw)
 }

--- a/rest/shared/src/main/scala/io/udash/rest/DefaultServerREST.scala
+++ b/rest/shared/src/main/scala/io/udash/rest/DefaultServerREST.scala
@@ -8,22 +8,12 @@ import scala.concurrent.ExecutionContext
 /** Default REST usage mechanism using [[io.udash.rest.DefaultRESTFramework]]. */
 class DefaultServerREST[ServerRPCType : DefaultRESTFramework.AsRealRPC : DefaultRESTFramework.RPCMetadata : DefaultRESTFramework.ValidREST]
                        (override protected val connector: RESTConnector)(implicit ec: ExecutionContext)
-  extends UsesREST[ServerRPCType] {
+  extends UsesREST[ServerRPCType] with RESTConverters {
 
   override val framework = DefaultRESTFramework
 
   override val remoteRpcAsReal: DefaultRESTFramework.AsRealRPC[ServerRPCType] = implicitly[DefaultRESTFramework.AsRealRPC[ServerRPCType]]
   override val rpcMetadata: framework.RPCMetadata[ServerRPCType] = implicitly[framework.RPCMetadata[ServerRPCType]]
-
-  def rawToHeaderArgument(raw: framework.RawValue): String =
-    stripQuotes(framework.rawToString(raw))
-  def rawToQueryArgument(raw: framework.RawValue): String =
-    stripQuotes(framework.rawToString(raw))
-  def rawToURLPart(raw: framework.RawValue): String =
-    URLEncoder.encode(stripQuotes(framework.rawToString(raw)))
-
-  private def stripQuotes(s: String): String =
-    s.stripPrefix("\"").stripSuffix("\"")
 }
 
 object DefaultServerREST {

--- a/rest/shared/src/main/scala/io/udash/rest/RESTConverters.scala
+++ b/rest/shared/src/main/scala/io/udash/rest/RESTConverters.scala
@@ -1,0 +1,30 @@
+package io.udash.rest
+
+import io.udash.rpc.serialization.URLEncoder
+
+trait RESTConverters {
+  val framework: UdashRESTFramework
+
+  // for ServerREST
+
+  def rawToHeaderArgument(raw: framework.RawValue): String =
+    stripQuotes(framework.rawToString(raw))
+  def rawToQueryArgument(raw: framework.RawValue): String =
+    stripQuotes(framework.rawToString(raw))
+  def rawToURLPart(raw: framework.RawValue): String =
+    URLEncoder.encode(stripQuotes(framework.rawToString(raw)))
+
+  private def stripQuotes(s: String): String =
+    s.stripPrefix("\"").stripSuffix("\"")
+
+  // for ExposesREST
+
+  def headerArgumentToRaw(raw: String, isStringArg: Boolean): framework.RawValue = rawArg(raw, isStringArg)
+  def queryArgumentToRaw(raw: String, isStringArg: Boolean): framework.RawValue  = rawArg(raw, isStringArg)
+  def urlPartToRaw(raw: String, isStringArg: Boolean): framework.RawValue =
+    rawArg(URLEncoder.decode(raw), isStringArg)
+
+  private def rawArg(raw: String, isStringArg: Boolean): framework.RawValue =
+    if (isStringArg) framework.stringToRaw(s""""$raw"""")
+    else framework.stringToRaw(raw)
+}


### PR DESCRIPTION
This makes it easier to write custom RESTFrameworks by extracting some boilerplate into a reusable core trait.

Fixes #124.