### PR TITLE
Add protocol parameter to DefaultServerREST and DefaultRESTConnector

### DIFF
--- a/rest/backend/src/test/scala/io/udash/rest/server/EndpointsIntegrationTest.scala
+++ b/rest/backend/src/test/scala/io/udash/rest/server/EndpointsIntegrationTest.scala
@@ -37,8 +37,8 @@ class EndpointsIntegrationTest extends UdashSharedTest with BeforeAndAfterAll wi
   context.addServlet(holder, s"${contextPrefix}*")
   server.setHandler(context)
 
-  val restServer = DefaultServerREST[TestServerRESTInterface]("127.0.0.1", port, contextPrefix)
-  val serverConnector = new DefaultRESTConnector("127.0.0.1", port, contextPrefix)
+  val restServer = DefaultServerREST[TestServerRESTInterface]("http", "127.0.0.1", port, contextPrefix)
+  val serverConnector = new DefaultRESTConnector("http", "127.0.0.1", port, contextPrefix)
 
   def await[T](f: Future[T]): T =
     Await.result(f, 3 seconds)

--- a/rest/shared/src/main/scala/io/udash/rest/DefaultRESTConnector.scala
+++ b/rest/shared/src/main/scala/io/udash/rest/DefaultRESTConnector.scala
@@ -3,7 +3,7 @@ package io.udash.rest
 import java.nio.ByteBuffer
 
 import monix.execution.Scheduler.Implicits.global
-import fr.hmil.roshttp.{HttpRequest, Method}
+import fr.hmil.roshttp.{HttpRequest, Method, Protocol}
 import fr.hmil.roshttp.body.BodyPart
 import io.udash.rest.internal.RESTConnector
 import io.udash.rest.internal.RESTConnector.HTTPMethod
@@ -13,13 +13,21 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.language.implicitConversions
 
 /** Default implementation of [[io.udash.rest.internal.RESTConnector]] for Udash REST. */
-class DefaultRESTConnector(val host: String, val port: Int, val pathPrefix: String)(implicit val ec: ExecutionContext) extends RESTConnector {
+class DefaultRESTConnector(_protocol: String, val host: String, val port: Int, val pathPrefix: String)(implicit val ec: ExecutionContext) extends RESTConnector {
+
+  private val protocol = _protocol match {
+    case "http:" | "http" => Protocol.HTTP
+    case "https:" | "https" => Protocol.HTTPS
+    case _ => throw new IllegalArgumentException(s"Invalid protocol: ${_protocol}")
+  }
+
   private class InternalBodyPart(override val content: Observable[ByteBuffer]) extends BodyPart {
     override val contentType: String = s"application/json; charset=utf-8"
   }
 
   override def send(url: String, method: HTTPMethod, queryArguments: Map[String, String], headers: Map[String, String], body: String): Future[String] = {
     val request: HttpRequest = HttpRequest()
+      .withProtocol(protocol)
       .withHost(host)
       .withPort(port)
       .withPath(pathPrefix.stripSuffix("/") + url)

--- a/rest/shared/src/main/scala/io/udash/rest/DefaultServerREST.scala
+++ b/rest/shared/src/main/scala/io/udash/rest/DefaultServerREST.scala
@@ -19,8 +19,8 @@ class DefaultServerREST[ServerRPCType : DefaultRESTFramework.AsRealRPC : Default
 object DefaultServerREST {
   /** Creates [[io.udash.rest.DefaultServerREST]] with [[io.udash.rest.DefaultRESTConnector]] for provided REST interfaces. */
   def apply[ServerRPCType : DefaultRESTFramework.AsRealRPC : DefaultRESTFramework.RPCMetadata : DefaultRESTFramework.ValidREST]
-           (host: String, port: Int, pathPrefix: String = "")(implicit ec: ExecutionContext): ServerRPCType = {
-    val serverConnector = new DefaultRESTConnector(host, port, pathPrefix)
+           (protocol: String, host: String, port: Int, pathPrefix: String = "")(implicit ec: ExecutionContext): ServerRPCType = {
+    val serverConnector = new DefaultRESTConnector(protocol, host, port, pathPrefix)
     val serverRPC: DefaultServerREST[ServerRPCType] = new DefaultServerREST[ServerRPCType](serverConnector)
     serverRPC.remoteRpc
   }


### PR DESCRIPTION
This allows client to specify HTTP or HTTPS for REST calls. It
accommodates including the final ':' from the URL scheme part so that
it's convenient to use with a DOM Location object.

    DefaultServerREST[ServerApi](
      dom.window.location.protocol,
      dom.window.location.hostname,
      dom.window.location.port.toInt,
      "/rest"
    )

Fixes #132