### PR TITLE
GenCodec instead of GenCodec.Auto in RPC, scala-commons 1.24.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ jsTestEnv in ThisBuild := new org.scalajs.jsenv.selenium.SeleniumJSEnv({
   import org.openqa.selenium.chrome.ChromeOptions
   val chrome = org.openqa.selenium.remote.DesiredCapabilities.chrome()
   val chromeOptions = new ChromeOptions()
-  chromeOptions.addArguments("--headless --disable-gpu")
+  chromeOptions.addArguments("--headless", "--disable-gpu")
   chrome.setCapability(ChromeOptions.CAPABILITY, chromeOptions)
   chrome
 })
@@ -73,10 +73,11 @@ lazy val `core-macros` = project.in(file("core/macros"))
 lazy val `core-shared` = crossProject.crossType(CrossType.Pure).in(file("core/shared"))
   .jsConfigure(_.dependsOn(`core-macros`))
   .jvmConfigure(_.dependsOn(`core-macros`))
-  .settings(commonSettings: _*).settings(
+  .settings(commonSettings: _*)
+  .settings(
     libraryDependencies ++= coreCrossDeps.value
   )
-  .jsSettings(commonJSSettings:_*)
+  .jsSettings(commonJSSettings: _*)
 
 lazy val `core-shared-JVM` = `core-shared`.jvm
 lazy val `core-shared-JS` = `core-shared`.js
@@ -102,7 +103,7 @@ lazy val `rpc-shared` = crossProject.crossType(CrossType.Full).in(file("rpc/shar
   .settings(
     libraryDependencies ++= rpcCrossTestDeps.value
   )
-  .jsSettings(commonJSSettings:_*)
+  .jsSettings(commonJSSettings: _*)
   .jvmSettings(
     libraryDependencies ++= rpcSharedJVMDeps.value
   )
@@ -113,8 +114,8 @@ lazy val `rpc-shared-JS` = `rpc-shared`.js
 lazy val `rpc-backend` = project.in(file("rpc/backend"))
   .dependsOn(`rpc-shared-JVM` % CompileAndTest)
   .settings(commonSettings: _*).settings(
-    libraryDependencies ++= rpcBackendDeps.value
-  )
+  libraryDependencies ++= rpcBackendDeps.value
+)
 
 lazy val `rpc-frontend` = project.in(file("rpc/frontend")).enablePlugins(ScalaJSPlugin)
   .dependsOn(`rpc-shared-JS` % CompileAndTest, `core-frontend` % CompileAndTest)
@@ -125,7 +126,8 @@ lazy val `rpc-frontend` = project.in(file("rpc/frontend")).enablePlugins(ScalaJS
   )
 
 lazy val `rest-macros` = project.in(file("rest/macros"))
-  .settings(commonSettings: _*).settings(
+  .settings(commonSettings: _*)
+  .settings(
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect" % scalaVersion.value,
       "com.avsystem.commons" %% "commons-macros" % avsCommonsVersion
@@ -136,10 +138,11 @@ lazy val `rest-shared` = crossProject.crossType(CrossType.Pure).in(file("rest/sh
   .configureCross(_.dependsOn(`rpc-shared` % CompileAndTest))
   .jsConfigure(_.dependsOn(`rest-macros`))
   .jvmConfigure(_.dependsOn(`rest-macros`))
-  .settings(commonSettings: _*).settings(
+  .settings(commonSettings: _*)
+  .settings(
     libraryDependencies ++= restCrossDeps.value
   )
-  .jsSettings(commonJSSettings:_*)
+  .jsSettings(commonJSSettings: _*)
 
 lazy val `rest-shared-JVM` = `rest-shared`.jvm
 lazy val `rest-shared-JS` = `rest-shared`.js
@@ -154,7 +157,7 @@ lazy val `rest-backend` = project.in(file("rest/backend"))
 lazy val `i18n-shared` = crossProject.crossType(CrossType.Pure).in(file("i18n/shared"))
   .configureCross(_.dependsOn(`core-shared`, `rpc-shared` % CompileAndTest))
   .settings(commonSettings: _*)
-  .jsSettings(commonJSSettings:_*)
+  .jsSettings(commonJSSettings: _*)
 
 lazy val `i18n-shared-JVM` = `i18n-shared`.jvm
 lazy val `i18n-shared-JS` = `i18n-shared`.js
@@ -172,7 +175,7 @@ lazy val `i18n-frontend` = project.in(file("i18n/frontend"))
 lazy val `auth-shared` = crossProject.crossType(CrossType.Pure).in(file("auth/shared"))
   .configureCross(_.dependsOn(`core-shared`, `rpc-shared` % CompileAndTest))
   .settings(commonSettings: _*)
-  .jsSettings(commonJSSettings:_*)
+  .jsSettings(commonJSSettings: _*)
 
 lazy val `auth-shared-JVM` = `auth-shared`.jvm
 lazy val `auth-shared-JS` = `auth-shared`.js
@@ -194,7 +197,7 @@ lazy val `css-shared` = crossProject.crossType(CrossType.Pure).in(file("css/shar
   .jsConfigure(_.dependsOn(`css-macros`, `core-shared-JS` % Test))
   .jvmConfigure(_.dependsOn(`css-macros`, `core-shared-JVM` % Test))
   .settings(commonSettings: _*)
-  .jsSettings(commonJSSettings:_*)
+  .jsSettings(commonJSSettings: _*)
   .settings(libraryDependencies ++= cssMacroDeps.value)
 
 lazy val `css-shared-JVM` = `css-shared`.jvm

--- a/core/macros/src/main/scala/io/udash/macros/PropertyMacros.scala
+++ b/core/macros/src/main/scala/io/udash/macros/PropertyMacros.scala
@@ -32,7 +32,6 @@ class PropertyMacros(val ctx: blackbox.Context) extends AbstractMacroCommons(ctx
   val PatchCls = tq"$Package.SeqProperty.Patch"
   val ArrayBufferCls = tq"_root_.scala.collection.mutable.ArrayBuffer"
   val MutableMap = q"_root_.scala.collection.mutable.Map"
-  val StringCls = tq"String"
 
   private lazy val OptionTpe = typeOf[Option[_]]
   private lazy val OptTpe = typeOf[Opt[_]]

--- a/i18n/shared/src/main/scala/io/udash/i18n/RemoteTranslationRPC.scala
+++ b/i18n/shared/src/main/scala/io/udash/i18n/RemoteTranslationRPC.scala
@@ -1,6 +1,5 @@
 package io.udash.i18n
 
-import com.avsystem.commons.rpc.RPCTypeClasses
 import io.udash.rpc.{DefaultServerUdashRPCFramework, RPC}
 
 import scala.concurrent.Future
@@ -22,4 +21,4 @@ trait RemoteTranslationRPC {
   /** Returns map of translations and bundle hash. If `oldHash` is not outdated, this Future will contain None. */
   def loadTranslationsForLang(lang: Lang, oldHash: BundleHash): Future[Option[Bundle]]
 }
-object RemoteTranslationRPC extends RPCTypeClasses[DefaultServerUdashRPCFramework.type, RemoteTranslationRPC]
+object RemoteTranslationRPC extends DefaultServerUdashRPCFramework.RPCCompanion[RemoteTranslationRPC]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val scalaCssVersion = "0.5.3"
 
   val servletVersion = "3.1.0"
-  val avsCommonsVersion = "1.23.1"
+  val avsCommonsVersion = "1.24.0"
 
   val atmosphereJSVersion = "2.3.4"
   val atmosphereVersion = "2.4.14"
@@ -93,7 +93,7 @@ object Dependencies {
 
   val bootstrapFrontendDeps = Def.setting(Seq(
     "io.udash" %%% "udash-jquery" % jqueryWrapperVersion,
-    "org.webjars" % "Eonasdan-bootstrap-datetimepicker" % bootstrapDatepickerVersion exclude ("org.webjars", "momentjs")
+    "org.webjars" % "Eonasdan-bootstrap-datetimepicker" % bootstrapDatepickerVersion exclude("org.webjars", "momentjs")
   ))
 
   val bootstrapFrontendJsDeps = Def.setting(Seq[org.scalajs.sbtplugin.JSModuleID](

--- a/rest/backend/src/test/scala/io/udash/rest/server/EndpointsIntegrationTest.scala
+++ b/rest/backend/src/test/scala/io/udash/rest/server/EndpointsIntegrationTest.scala
@@ -82,7 +82,6 @@ class EndpointsIntegrationTest extends UdashSharedTest with BeforeAndAfterAll wi
       firesBuffer.clear()
       restServer.serviceTwo("token123", "en_GB").fireAndForget(321)
       eventually {
-        println(firesBuffer)
         firesBuffer.contains("two/token123/en_GB/fireAndForget/321") should be(true)
       }
     }

--- a/rest/macros/src/main/scala/io/udash/rest/macros/RESTMacros.scala
+++ b/rest/macros/src/main/scala/io/udash/rest/macros/RESTMacros.scala
@@ -1,10 +1,10 @@
 package io.udash.rest.macros
 
-import com.avsystem.commons.macros.rpc.RPCMacros
+import com.avsystem.commons.macros.rpc.RPCFrameworkMacros
 
 import scala.reflect.macros.blackbox
 
-class RESTMacros(override val c: blackbox.Context) extends RPCMacros(c) {
+class RESTMacros(override val c: blackbox.Context) extends RPCFrameworkMacros(c) {
 
   import c.universe._
 
@@ -69,11 +69,11 @@ class RESTMacros(override val c: blackbox.Context) extends RPCMacros(c) {
     checkNameOverride(method.method.annotations,
       cls => s"@$cls annotation argument has to be non empty string, value on ${method.rpcName} in $restType is not.")
 
-  def checkParameterNameOverride(parameter:  Symbol, method: ProxyableMember, restType: Type) =
+  def checkParameterNameOverride(parameter: Symbol, method: ProxyableMember, restType: Type) =
     checkNameOverride(parameter.annotations,
       cls => s"@$cls annotation argument has to be non empty string, value on ${parameter.name} from ${method.rpcName} in $restType is not.")
 
-  def checkParameterTypeAnnotations(parameter:  Symbol, method: ProxyableMember, restType: Type) =
+  def checkParameterTypeAnnotations(parameter: Symbol, method: ProxyableMember, restType: Type) =
     if (countArgumentTypeAnnotation(parameter.annotations) > 1)
       abort(s"REST method argument has to be annotated with at most one argument type annotation, ${parameter.name} from ${method.rpcName} in $restType has not.")
 
@@ -124,8 +124,10 @@ class RESTMacros(override val c: blackbox.Context) extends RPCMacros(c) {
         paramsList.foreach(param => checkGetterParameter(param, getter, restType))
       )
 
-      if (!isServer) q"""implicitly[$ValidRESTCls[${getter.returnType}]]"""
-      else q"""implicitly[$ValidServerRESTCls[${getter.returnType}]]"""
+      if (!isServer)
+        q"""implicitly[$ValidRESTCls[${getter.returnType}]]"""
+      else
+        q"""implicitly[$ValidServerRESTCls[${getter.returnType}]]"""
     })
 
     val methodsImplicits = methods.map(method => {
@@ -147,7 +149,7 @@ class RESTMacros(override val c: blackbox.Context) extends RPCMacros(c) {
     })
 
     val cls = if (!isServer) ValidRESTCls else ValidServerRESTCls
-      q"""
+    q"""
       new $cls[$restType] {
         implicit def ${c.freshName(TermName("self"))}: $cls[$restType] = this
 

--- a/rest/shared/src/main/scala/io/udash/rest/DefaultRESTFramework.scala
+++ b/rest/shared/src/main/scala/io/udash/rest/DefaultRESTFramework.scala
@@ -4,7 +4,7 @@ import com.avsystem.commons.serialization.GenCodec
 import io.udash.rpc.{AutoUdashRPCFramework, DefaultUdashSerialization}
 
 object DefaultRESTFramework extends UdashRESTFramework with AutoUdashRPCFramework with DefaultUdashSerialization {
-  private val bodyValuesCodec = GenCodec.Auto(GenCodec.create[Map[String, DefaultRESTFramework.RawValue]](
+  private val bodyValuesCodec = GenCodec.create[Map[String, DefaultRESTFramework.RawValue]](
     in => {
       val data = Map.newBuilder[String, DefaultRESTFramework.RawValue]
       val obj = in.readObject()
@@ -21,7 +21,7 @@ object DefaultRESTFramework extends UdashRESTFramework with AutoUdashRPCFramewor
       }
       obj.finish()
     }
-  ))
+  )
 
   override def bodyValuesWriter: DefaultRESTFramework.Writer[Map[String, DefaultRESTFramework.RawValue]] =
     bodyValuesCodec

--- a/rest/shared/src/test/scala/io/udash/rest/TestRESTInterface.scala
+++ b/rest/shared/src/test/scala/io/udash/rest/TestRESTInterface.scala
@@ -1,10 +1,12 @@
 package io.udash.rest
 
+import com.avsystem.commons.serialization.HasGenCodec
 import io.udash.rpc.RPCName
 
 import scala.concurrent.Future
 
 case class TestRESTRecord(id: Option[Int], s: String)
+object TestRESTRecord extends HasGenCodec[TestRESTRecord]
 
 @REST
 trait TestRESTInterface {

--- a/rpc/shared/shared/src/main/scala/io/udash/rpc/frameworks.scala
+++ b/rpc/shared/shared/src/main/scala/io/udash/rpc/frameworks.scala
@@ -6,19 +6,19 @@ import com.avsystem.commons.serialization._
 import scala.language.postfixOps
 
 trait GenCodecSerializationFramework { this: RPCFramework =>
-  type Writer[T] = GenCodec.Auto[T]
-  type Reader[T] = GenCodec.Auto[T]
+  type Writer[T] = GenCodec[T]
+  type Reader[T] = GenCodec[T]
 
   /** Converts value of type `T` into `RawValue`. */
   def write[T: Writer](value: T): RawValue = {
     var result: RawValue = null.asInstanceOf[RawValue]
-    GenCodec.autoWrite[T](outputSerialization(result = _), value)
+    GenCodec.write[T](outputSerialization(result = _), value)
     result
   }
 
   /** Converts `RawValue` into value of type `T`. */
   def read[T: Reader](raw: RawValue): T =
-    GenCodec.autoRead[T](inputSerialization(raw))
+    GenCodec.read[T](inputSerialization(raw))
 
   /** Returns `Input` for data marshalling. */
   def inputSerialization(value: RawValue): Input
@@ -38,12 +38,14 @@ trait AutoUdashRPCFramework extends GenCodecSerializationFramework { this: RPCFr
 
 /** Base RPC framework for client RPC interface. This one does not allow RPC interfaces to contain methods with return type `Future[T]`. */
 trait ClientUdashRPCFramework extends UdashRPCFramework {
-  trait RawRPC extends GetterRawRPC with ProcedureRawRPC
+  abstract class RawRPC extends GetterRawRPC with ProcedureRawRPC
+  abstract class FullRPCInfo[T] extends BaseFullRPCInfo[T] // for better ScalaJS DCE, MUST be separate from server framework
 }
 
 /** Base RPC framework for server RPC interface. This one allows RPC interfaces to contain methods with return type `Future[T]`. */
 trait ServerUdashRPCFramework extends UdashRPCFramework with FunctionRPCFramework {
-  trait RawRPC extends GetterRawRPC with FunctionRawRPC with ProcedureRawRPC
+  abstract class RawRPC extends GetterRawRPC with FunctionRawRPC with ProcedureRawRPC
+  abstract class FullRPCInfo[T] extends BaseFullRPCInfo[T] // for better ScalaJS DCE, MUST be separate from client framework
 }
 
 /** Default Udash client application RPC framework. */

--- a/rpc/shared/shared/src/main/scala/io/udash/rpc/frameworks.scala
+++ b/rpc/shared/shared/src/main/scala/io/udash/rpc/frameworks.scala
@@ -38,14 +38,14 @@ trait AutoUdashRPCFramework extends GenCodecSerializationFramework { this: RPCFr
 
 /** Base RPC framework for client RPC interface. This one does not allow RPC interfaces to contain methods with return type `Future[T]`. */
 trait ClientUdashRPCFramework extends UdashRPCFramework {
-  abstract class RawRPC extends GetterRawRPC with ProcedureRawRPC
-  abstract class FullRPCInfo[T] extends BaseFullRPCInfo[T] // for better ScalaJS DCE, MUST be separate from server framework
+  trait RawRPC extends GetterRawRPC with ProcedureRawRPC
+  trait FullRPCInfo[T] extends BaseFullRPCInfo[T] // for better ScalaJS DCE, MUST be separate from server framework
 }
 
 /** Base RPC framework for server RPC interface. This one allows RPC interfaces to contain methods with return type `Future[T]`. */
 trait ServerUdashRPCFramework extends UdashRPCFramework with FunctionRPCFramework {
-  abstract class RawRPC extends GetterRawRPC with FunctionRawRPC with ProcedureRawRPC
-  abstract class FullRPCInfo[T] extends BaseFullRPCInfo[T] // for better ScalaJS DCE, MUST be separate from client framework
+  trait RawRPC extends GetterRawRPC with FunctionRawRPC with ProcedureRawRPC
+  trait FullRPCInfo[T] extends BaseFullRPCInfo[T] // for better ScalaJS DCE, MUST be separate from client framework
 }
 
 /** Default Udash client application RPC framework. */

--- a/rpc/shared/shared/src/test/scala/io/udash/rpc/TestRPC.scala
+++ b/rpc/shared/shared/src/test/scala/io/udash/rpc/TestRPC.scala
@@ -1,11 +1,14 @@
 package io.udash.rpc
 
+import com.avsystem.commons.serialization.HasGenCodec
 import com.github.ghik.silencer.silent
 import io.udash.rpc.utils.Logged
 
 import scala.concurrent.Future
 
 case class Record(i: Int, fuu: String)
+object Record extends HasGenCodec[Record]
+
 case class CustomRPCException(i: Int) extends Throwable
 
 trait RPCMethods {

--- a/rpc/shared/shared/src/test/scala/io/udash/rpc/types.scala
+++ b/rpc/shared/shared/src/test/scala/io/udash/rpc/types.scala
@@ -1,9 +1,18 @@
 package io.udash.rpc
 
-case class TestCC(i: Int, l: Long, intAsDouble: Double, b: Boolean, s: String, list: List[Char])
-case class NestedTestCC(i: Int, t: TestCC, t2: TestCC)
-case class DeepNestedTestCC(n: NestedTestCC, l: DeepNestedTestCC)
+import com.avsystem.commons.serialization.HasGenCodec
 
-case class CompleteItem(unit: Unit, string: String, specialString: String, char: Char, boolean: Boolean, byte: Byte, short: Short, int: Int,
-                        long: Long, float: Float, double: Double, binary: Array[Byte], list: List[String],
-                        set: Set[String], obj: TestCC, map: Map[String, Int])
+case class TestCC(i: Int, l: Long, intAsDouble: Double, b: Boolean, s: String, list: List[Char])
+object TestCC extends HasGenCodec[TestCC]
+
+case class NestedTestCC(i: Int, t: TestCC, t2: TestCC)
+object NestedTestCC extends HasGenCodec[NestedTestCC]
+
+case class DeepNestedTestCC(n: NestedTestCC, l: DeepNestedTestCC)
+object DeepNestedTestCC extends HasGenCodec[DeepNestedTestCC]
+
+case class CompleteItem(
+  unit: Unit, string: String, specialString: String, char: Char, boolean: Boolean, byte: Byte, short: Short, int: Int,
+  long: Long, float: Float, double: Double, binary: Array[Byte], list: List[String], set: Set[String],
+  obj: TestCC, map: Map[String, Int])
+object CompleteItem extends HasGenCodec[CompleteItem]


### PR DESCRIPTION
* RPC frameworks now require `GenCodec` instead of `GenCodec.Auto`
* commons 1.24.0
* migrated `RPCTypeClasses` to JS-DCE-friendly `RPCCompanion`
