### PR TITLE
Remove all items from a SeqProperty that satisfy a predicate

### DIFF
--- a/core/frontend/src/main/scala/io/udash/properties/seq/SeqProperty.scala
+++ b/core/frontend/src/main/scala/io/udash/properties/seq/SeqProperty.scala
@@ -156,9 +156,10 @@ trait SeqProperty[A, +ElemType <: Property[A]] extends ReadableSeqProperty[A, El
   def remove(idx: Int, amount: Int): Unit = replace(idx, amount)
 
   /** Removes all elements that match `predicate`. */
-  def remove(predicate: A => Boolean): Unit = get.zipWithIndex.filter { case (element, _) =>
-    predicate(element)
-  }.foreach(i => remove(i._2, 1))
+  def remove(predicate: A => Boolean): Unit = {
+    val toDelete = get.filter(predicate)
+    toDelete.foreach(remove)
+  }
 
   /** Removes first occurrence of `value`. */
   def remove(value: A): Unit = {

--- a/core/frontend/src/main/scala/io/udash/properties/seq/SeqProperty.scala
+++ b/core/frontend/src/main/scala/io/udash/properties/seq/SeqProperty.scala
@@ -155,6 +155,11 @@ trait SeqProperty[A, +ElemType <: Property[A]] extends ReadableSeqProperty[A, El
   /** Removes `amount` elements starting from index `idx`. */
   def remove(idx: Int, amount: Int): Unit = replace(idx, amount)
 
+  /** Removes all elements that match `predicate`. */
+  def remove(predicate: A => Boolean): Unit = get.zipWithIndex.filter { case (element, _) =>
+    predicate(element)
+  }.foreach(i => remove(i._2, 1))
+
   /** Removes first occurrence of `value`. */
   def remove(value: A): Unit = {
     val idx: Int = elemProperties.map(p => p.get).indexOf(value)

--- a/core/frontend/src/test/scala/io/udash/properties/PropertyTest.scala
+++ b/core/frontend/src/test/scala/io/udash/properties/PropertyTest.scala
@@ -1238,15 +1238,16 @@ class PropertyTest extends UdashFrontendTest {
     }
 
     "remove all items that satisfy a predicate" in {
-      var values = Seq.empty[Int]
-      val listener = (s: Seq[Int]) => values = s
-      val p = SeqProperty[Int](1,2,3,4,5)
-      p.listen(listener, initUpdate = true)
+      case class Thing(id: Int)
+      var values = Seq.empty[Thing]
+      val listener = (s: Seq[Thing]) => values = s
+      val p = SeqProperty[Thing](Thing(1), Thing(2), Thing(3), Thing(4), Thing(5))
+      p.listen(listener)
 
       p.get.size should be(5)
-      p.remove(_ < 5)
-      p.get should be(Seq(5))
-      values should be(Seq(5))
+      p.remove(_.id < 5)
+      p.get should be(Seq(Thing(5)))
+      values should be(Seq(Thing(5)))
     }
 
     "fire value listeners on every child change" in {

--- a/core/frontend/src/test/scala/io/udash/properties/PropertyTest.scala
+++ b/core/frontend/src/test/scala/io/udash/properties/PropertyTest.scala
@@ -1237,6 +1237,18 @@ class PropertyTest extends UdashFrontendTest {
       oneTimeValues.last should be(Seq(1, 2, 3))
     }
 
+    "remove all items that satisfy a predicate" in {
+      var values = Seq.empty[Int]
+      val listener = (s: Seq[Int]) => values = s
+      val p = SeqProperty[Int](1,2,3,4,5)
+      p.listen(listener, initUpdate = true)
+
+      p.get.size should be(5)
+      p.remove(_ < 5)
+      p.get should be(Seq(5))
+      values should be(Seq(5))
+    }
+
     "fire value listeners on every child change" in {
       val p = SeqProperty[Int]
 


### PR DESCRIPTION
Today I wanted to remove an item for a SeqProperty by id and was looking for a method to do this.

It didn't exist so I added it.

The performance implications are worth discussing: I'm not sure if `zipWithIndex` creates an eager or lazy list and therefore if the list is traversed once or twice.