### PR TITLE
Explicitly type Udash RPC raw value as String

### DIFF
--- a/rest/shared/src/main/scala/io/udash/rest/DefaultRESTFramework.scala
+++ b/rest/shared/src/main/scala/io/udash/rest/DefaultRESTFramework.scala
@@ -1,31 +1,8 @@
 package io.udash.rest
 
-import com.avsystem.commons.serialization.GenCodec
-import io.udash.rpc.{AutoUdashRPCFramework, DefaultUdashSerialization}
+import io.udash.rpc.{DefaultUdashSerialization, GenCodecSerializationFramework}
 
-object DefaultRESTFramework extends UdashRESTFramework with AutoUdashRPCFramework with DefaultUdashSerialization {
-  private val bodyValuesCodec = GenCodec.create[Map[String, DefaultRESTFramework.RawValue]](
-    in => {
-      val data = Map.newBuilder[String, DefaultRESTFramework.RawValue]
-      val obj = in.readObject()
-      while (obj.hasNext) {
-        val f = obj.nextField()
-        data += (f.fieldName -> stringToRaw(f.readString()))
-      }
-      data.result()
-    },
-    (out, e) => {
-      val obj = out.writeObject()
-      for ((key, value) <- e) {
-        obj.writeField(key).writeString(rawToString(value))
-      }
-      obj.finish()
-    }
-  )
-
-  override def bodyValuesWriter: DefaultRESTFramework.Writer[Map[String, DefaultRESTFramework.RawValue]] =
-    bodyValuesCodec
-
-  override def bodyValuesReader: DefaultRESTFramework.Reader[Map[String, DefaultRESTFramework.RawValue]] =
-    bodyValuesCodec
+object DefaultRESTFramework extends UdashRESTFramework with DefaultUdashSerialization with GenCodecSerializationFramework {
+  override val bodyValuesWriter: DefaultRESTFramework.Writer[Map[String, String]] = implicitly
+  override val bodyValuesReader: DefaultRESTFramework.Reader[Map[String, String]] = implicitly
 }

--- a/rest/shared/src/main/scala/io/udash/rest/RESTConverters.scala
+++ b/rest/shared/src/main/scala/io/udash/rest/RESTConverters.scala
@@ -7,12 +7,9 @@ trait RESTConverters {
 
   // for ServerREST
 
-  def rawToHeaderArgument(raw: framework.RawValue): String =
-    stripQuotes(framework.rawToString(raw))
-  def rawToQueryArgument(raw: framework.RawValue): String =
-    stripQuotes(framework.rawToString(raw))
-  def rawToURLPart(raw: framework.RawValue): String =
-    URLEncoder.encode(stripQuotes(framework.rawToString(raw)))
+  def rawToHeaderArgument(raw: framework.RawValue): String = stripQuotes(raw)
+  def rawToQueryArgument(raw: framework.RawValue): String = stripQuotes(raw)
+  def rawToURLPart(raw: framework.RawValue): String = URLEncoder.encode(stripQuotes(raw))
 
   private def stripQuotes(s: String): String =
     s.stripPrefix("\"").stripSuffix("\"")
@@ -25,6 +22,6 @@ trait RESTConverters {
     rawArg(URLEncoder.decode(raw), isStringArg)
 
   private def rawArg(raw: String, isStringArg: Boolean): framework.RawValue =
-    if (isStringArg) framework.stringToRaw(s""""$raw"""")
-    else framework.stringToRaw(raw)
+    if (isStringArg) s""""$raw""""
+    else raw
 }

--- a/rest/shared/src/main/scala/io/udash/rest/UdashRESTFramework.scala
+++ b/rest/shared/src/main/scala/io/udash/rest/UdashRESTFramework.scala
@@ -5,15 +5,11 @@ import com.avsystem.commons.rpc.{FunctionRPCFramework, GetterRPCFramework, Proce
 trait UdashRESTFramework extends GetterRPCFramework with ProcedureRPCFramework with FunctionRPCFramework {
   trait RawRPC extends GetterRawRPC with ProcedureRawRPC with FunctionRawRPC
 
+  type RawValue = String
   type ParamTypeMetadata[T] = SimplifiedType[T]
 
   class ResultTypeMetadata[+T]
   implicit object ResultTypeMetadata extends ResultTypeMetadata[Nothing]
-
-  /** Transform `String` received from HTTP response to `RawValue`. */
-  def stringToRaw(string: String): RawValue
-  /** Transform `RawValue` to `String` for HTTP request body. */
-  def rawToString(raw: RawValue): String
 
   def bodyValuesWriter: Writer[Map[String, RawValue]]
   def bodyValuesReader: Reader[Map[String, RawValue]]

--- a/rpc/backend/src/main/scala/io/udash/rpc/DefaultClientRPC.scala
+++ b/rpc/backend/src/main/scala/io/udash/rpc/DefaultClientRPC.scala
@@ -20,9 +20,9 @@ abstract class ClientRPC[ClientRPCType](target: ClientRPCTarget)
     val msg: RawValue = write[RPCRequest](RPCFire(invocation, getterChain))
     target match {
       case AllClients =>
-        BroadcastManager.broadcast(rawToString(msg))
+        BroadcastManager.broadcast(msg)
       case ClientId(clientId) =>
-        BroadcastManager.sendToClient(clientId, rawToString(msg))
+        BroadcastManager.sendToClient(clientId, msg)
     }
   }
 
@@ -32,7 +32,7 @@ abstract class ClientRPC[ClientRPCType](target: ClientRPCTarget)
 /** Default implementation of [[io.udash.rpc.ClientRPC]] for server to client communication. */
 class DefaultClientRPC[ClientRPCType : DefaultClientUdashRPCFramework.AsRealRPC]
                       (target: ClientRPCTarget)(implicit ec: ExecutionContext) extends ClientRPC[ClientRPCType](target) {
-  override val localFramework = DefaultServerUdashRPCFramework
-  override val remoteFramework = DefaultClientUdashRPCFramework
+  override val localFramework: DefaultServerUdashRPCFramework.type = DefaultServerUdashRPCFramework
+  override val remoteFramework: DefaultClientUdashRPCFramework.type = DefaultClientUdashRPCFramework
   protected val remoteRpcAsReal: DefaultClientUdashRPCFramework.AsRealRPC[ClientRPCType] = implicitly[DefaultClientUdashRPCFramework.AsRealRPC[ClientRPCType]]
 }

--- a/rpc/backend/src/main/scala/io/udash/rpc/utils/CallLogging.scala
+++ b/rpc/backend/src/main/scala/io/udash/rpc/utils/CallLogging.scala
@@ -23,7 +23,7 @@ trait CallLogging[ServerRPCType] extends ExposesServerRPC[ServerRPCType] {
       .get(call.invocation.rpcName)
       .filter(_.annotations.exists(_.isInstanceOf[Logged]))
       .foreach(methodMetadata =>
-        log(classMetadata.name, methodMetadata.methodName, call.invocation.argLists.flatMap(_.map(localFramework.rawToString)))
+        log(classMetadata.name, methodMetadata.methodName, call.invocation.argLists.flatten)
       )
     super.handleRpcCall(call)
   }

--- a/rpc/frontend/src/main/scala/io/udash/rpc/internals/ServerConnector.scala
+++ b/rpc/frontend/src/main/scala/io/udash/rpc/internals/ServerConnector.scala
@@ -78,16 +78,14 @@ abstract class AtmosphereServerConnector[RPCRequest](
   private def handleMessage(msg: String) = {
     try {
       import remoteFramework.RPCResponseCodec
-      val rawMsg = remoteFramework.stringToRaw(msg)
-      val rawMsgInput: Input = remoteFramework.inputSerialization(rawMsg)
+      val rawMsgInput: Input = remoteFramework.inputSerialization(msg)
       val response = RPCResponseCodec(exceptionsRegistry).read(rawMsgInput)
       handleResponse(response)
     } catch {
       case _: Exception =>
         try {
           import localFramework.RPCRequestCodec
-          val rawMsg = localFramework.stringToRaw(msg)
-          val rawMsgInput: Input = localFramework.inputSerialization(rawMsg)
+          val rawMsgInput: Input = localFramework.inputSerialization(msg)
           RPCRequestCodec.read(rawMsgInput) match {
             case fire: localFramework.RPCFire =>
               handleRpcFire(fire)
@@ -158,11 +156,11 @@ class DefaultAtmosphereServerConnector(override protected val clientRpc: Default
                                        override val exceptionsRegistry: ExceptionCodecRegistry)
   extends AtmosphereServerConnector[DefaultServerUdashRPCFramework.RPCRequest](serverUrl, exceptionsRegistry) {
 
-  override val remoteFramework = DefaultServerUdashRPCFramework
-  override val localFramework = DefaultClientUdashRPCFramework
+  override val remoteFramework: DefaultServerUdashRPCFramework.type = DefaultServerUdashRPCFramework
+  override val localFramework: DefaultClientUdashRPCFramework.type = DefaultClientUdashRPCFramework
 
   override def requestToString(request: remoteFramework.RPCRequest): String =
-    remoteFramework.rawToString(remoteFramework.write(request))
+    remoteFramework.write(request)
 
   override def handleResponse(response: remoteFramework.RPCResponse): Any =
     responseHandler(response)

--- a/rpc/shared/src/main/scala/io/udash/rpc/UdashRPCFramework.scala
+++ b/rpc/shared/src/main/scala/io/udash/rpc/UdashRPCFramework.scala
@@ -8,6 +8,7 @@ import scala.language.postfixOps
 
 /** Base for all RPC frameworks in Udash. */
 trait UdashRPCFramework extends GetterRPCFramework with ProcedureRPCFramework with GenCodecSerializationFramework {
+  override type RawValue = String
   type RawRPC <: GetterRawRPC with ProcedureRawRPC
 
   class ParamTypeMetadata[+T]
@@ -16,16 +17,7 @@ trait UdashRPCFramework extends GetterRPCFramework with ProcedureRPCFramework wi
   class ResultTypeMetadata[+T]
   implicit object ResultTypeMetadata extends ResultTypeMetadata[Nothing]
 
-  val RawValueCodec: GenCodec[RawValue]
-
-  private implicit def rawCodec: GenCodec[RawValue] =
-    RawValueCodec
-
-  /** Converts `String` into `RawValue`. It is used to read data from network. */
-  def stringToRaw(string: String): RawValue
-
-  /** Converts `RawValue` into `String`. It is used to write data to network. */
-  def rawToString(raw: RawValue): String
+  val RawValueCodec: GenCodec[RawValue] = implicitly
 
   sealed trait RPCRequest {
     def invocation: RawInvocation
@@ -176,19 +168,6 @@ trait UdashRPCFramework extends GetterRPCFramework with ProcedureRPCFramework wi
             val exceptionField = obj.writeField("exception").writeObject()
             exceptionField.writeField("type").writeString(name)
             exceptionsRegistry.get(name).write(exceptionField.writeField("data"), exception)
-//            val stack = exceptionField.writeField("stacktrace")
-//            if (exception.getStackTrace != null) {
-//              val stackList = stack.writeList()
-//              exception.getStackTrace.foreach { element =>
-//                val field = stackList.writeElement().writeObject()
-//                field.writeField("fileName").writeString(element.getFileName)
-//                field.writeField("className").writeString(element.getClassName)
-//                field.writeField("methodName").writeString(element.getMethodName)
-//                field.writeField("line").writeInt(element.getLineNumber)
-//                field.finish()
-//              }
-//              stackList.finish()
-//            } else stack.writeNull()
             exceptionField.finish()
             obj.writeField("callId").writeString(callId)
         }

--- a/rpc/shared/src/main/scala/io/udash/rpc/frameworks.scala
+++ b/rpc/shared/src/main/scala/io/udash/rpc/frameworks.scala
@@ -26,16 +26,6 @@ trait GenCodecSerializationFramework { this: RPCFramework =>
   def outputSerialization(valueConsumer: RawValue => Unit): Output
 }
 
-/** Mixin for RPC framework with automatic `GenCodec` to `String` serialization. */
-trait AutoUdashRPCFramework extends GenCodecSerializationFramework { this: RPCFramework =>
-  type RawValue = String
-
-  val RawValueCodec = implicitly[GenCodec[String]]
-
-  def stringToRaw(string: String): RawValue = string
-  def rawToString(raw: RawValue): String = raw
-}
-
 /** Base RPC framework for client RPC interface. This one does not allow RPC interfaces to contain methods with return type `Future[T]`. */
 trait ClientUdashRPCFramework extends UdashRPCFramework {
   trait RawRPC extends GetterRawRPC with ProcedureRawRPC
@@ -49,6 +39,6 @@ trait ServerUdashRPCFramework extends UdashRPCFramework with FunctionRPCFramewor
 }
 
 /** Default Udash client application RPC framework. */
-object DefaultClientUdashRPCFramework extends AutoUdashRPCFramework with ClientUdashRPCFramework with DefaultUdashSerialization
+object DefaultClientUdashRPCFramework extends ClientUdashRPCFramework with DefaultUdashSerialization
 /** Default Udash server application RPC framework. */
-object DefaultServerUdashRPCFramework extends AutoUdashRPCFramework with ServerUdashRPCFramework with DefaultUdashSerialization
+object DefaultServerUdashRPCFramework extends ServerUdashRPCFramework with DefaultUdashSerialization

--- a/rpc/shared/src/test/scala/io/udash/rpc/RpcMessagesTest.scala
+++ b/rpc/shared/src/test/scala/io/udash/rpc/RpcMessagesTest.scala
@@ -24,11 +24,11 @@ trait RpcMessagesTestScenarios extends UdashSharedTest with Utils {
 
     implicit val codec: GenCodec[RPCResponse] = RPCResponseCodec(exceptionsRegistry)
 
-    val inv = RawInvocation("r{p[c\"]}Name", List(List(stringToRaw(s""""${EscapeUtils.escape("val{lu} [e1\"2]3")}""""))))
-    val getter1 = RawInvocation("g{}[]\",\"etter1", List(List(stringToRaw("\",a\""), stringToRaw("\"B,,\""), stringToRaw("\"v\"")), List(stringToRaw("\"xy,z\""))))
+    val inv = RawInvocation("r{p[c\"]}Name", List(List(s""""${EscapeUtils.escape("val{lu} [e1\"2]3")}"""")))
+    val getter1 = RawInvocation("g{}[]\",\"etter1", List(List("\",a\"", "\"B,,\"", "\"v\""), List("\"xy,z\"")))
     val getter2 = RawInvocation("ge{[[\"a,sd\"]][]}t,ter2", Nil)
     val req = RPCCall(inv, getter1 :: getter2 :: Nil, "\"call1\"")
-    val success = RPCResponseSuccess(stringToRaw(s""""${EscapeUtils.escape("val{lu} [e1\"2]3")}""""), "\"ca{[]}ll1\"")
+    val success = RPCResponseSuccess(s""""${EscapeUtils.escape("val{lu} [e1\"2]3")}"""", "\"ca{[]}ll1\"")
     val failure = RPCResponseFailure("\\ca{}[]\"\"use\\\\", "[{msg}: \"abc\"]", "\"ca{[]}ll1\"")
     val exception = RPCResponseException(CustomException("test", 5).getClass.getName, CustomException("test", 5), "\"ca{[]}ll1\"")
     val runtimeException = RPCResponseException(new NullPointerException("test").getClass.getName, new NullPointerException(null), "\"ca{[]}ll1\"")
@@ -162,36 +162,36 @@ trait RpcMessagesTestScenarios extends UdashSharedTest with Utils {
     }
 
     "handle plain numbers in JSON as Int, Long and Double" in {
-      val json = RPC.stringToRaw("123")
+      val json = "123"
       RPC.read[Int](json) should be(123)
       RPC.read[Long](json) should be(123)
       RPC.read[Double](json) should be(123)
 
       val maxIntPlusOne: Long = Int.MaxValue.toLong + 1
-      val jsonLong = RPC.stringToRaw(maxIntPlusOne.toString)
+      val jsonLong = maxIntPlusOne.toString
       intercept[ReadFailure](RPC.read[Int](jsonLong))
       RPC.read[Long](jsonLong) should be(maxIntPlusOne)
       RPC.read[Double](jsonLong) should be(maxIntPlusOne)
 
-      val jsonLongMax = RPC.stringToRaw(Long.MaxValue.toString)
+      val jsonLongMax = Long.MaxValue.toString
       intercept[ReadFailure](RPC.read[Int](jsonLong))
       RPC.read[Long](jsonLongMax) should be(Long.MaxValue)
       RPC.read[Double](jsonLongMax) should be(Long.MaxValue)
 
-      val jsonDouble = RPC.stringToRaw(Double.MaxValue.toString)
+      val jsonDouble = Double.MaxValue.toString
       intercept[ReadFailure](RPC.read[Int](jsonDouble))
       intercept[ReadFailure](RPC.read[Long](jsonDouble))
       RPC.read[Double](jsonDouble) should be(Double.MaxValue)
 
-      val jsonDouble2 = RPC.stringToRaw("123.00")
+      val jsonDouble2 = "123.00"
       RPC.read[Int](jsonDouble2) should be(123)
       RPC.read[Long](jsonDouble2) should be(123)
       RPC.read[Double](jsonDouble2) should be(123.0)
 
       val brokenDouble = "312,321"
-      intercept[ReadFailure](RPC.read[Int](RPC.stringToRaw(brokenDouble)))
-      intercept[ReadFailure](RPC.read[Long](RPC.stringToRaw(brokenDouble)))
-      intercept[ReadFailure](RPC.read[Double](RPC.stringToRaw(brokenDouble)))
+      intercept[ReadFailure](RPC.read[Int](brokenDouble))
+      intercept[ReadFailure](RPC.read[Long](brokenDouble))
+      intercept[ReadFailure](RPC.read[Double](brokenDouble))
     }
 
     "work with skipping" in {

--- a/rpc/shared/src/test/scala/io/udash/rpc/SerializationIntegrationTestBase.scala
+++ b/rpc/shared/src/test/scala/io/udash/rpc/SerializationIntegrationTestBase.scala
@@ -19,8 +19,8 @@ class SerializationIntegrationTestBase extends UdashSharedTest with Utils {
           else DeepNestedTestCC(ncc(), null)
 
         val test: DeepNestedTestCC = dncc()
-        val serialized = writer.rawToString(writer.write(test))
-        val deserialized = reader.read[DeepNestedTestCC](reader.stringToRaw(serialized))
+        val serialized = writer.write(test)
+        val deserialized = reader.read[DeepNestedTestCC](serialized)
 
         deserialized should be(test)
       }
@@ -51,8 +51,8 @@ class SerializationIntegrationTestBase extends UdashSharedTest with Utils {
       )
 
       testOpts.foreach(opt => {
-        val serialized = writer.rawToString(writer.write(opt))
-        val deserialized = reader.read[Option[Long]](reader.stringToRaw(serialized))
+        val serialized = writer.write(opt)
+        val deserialized = reader.read[Option[Long]](serialized)
         deserialized should be(opt)
       })
     }


### PR DESCRIPTION
Since we have to provide a mapping to String anyway (via `stringToRaw` and `rawToString`), we can simplify the code a lot if we explicitly state that we're dealing with frameworks producing String `RawValue`s.