### PR TITLE
Use sequential property IDs

### DIFF
--- a/core/shared/.js/src/main/scala/io/udash/properties/PropertyIdGenerator.scala
+++ b/core/shared/.js/src/main/scala/io/udash/properties/PropertyIdGenerator.scala
@@ -1,0 +1,10 @@
+package io.udash.properties
+
+private[properties] object PropertyIdGenerator {
+  private var last = -1L
+
+  def next(): PropertyId = {
+    last += 1
+    PropertyId(last)
+  }
+}

--- a/core/shared/.jvm/src/main/scala/io/udash/properties/PropertyIdGenerator.scala
+++ b/core/shared/.jvm/src/main/scala/io/udash/properties/PropertyIdGenerator.scala
@@ -1,0 +1,11 @@
+package io.udash.properties
+
+import java.util.concurrent.atomic.AtomicLong
+
+private[properties] object PropertyIdGenerator {
+  private val last = new AtomicLong(-1)
+
+  private[properties] def next(): PropertyId = {
+    PropertyId(last.incrementAndGet())
+  }
+}

--- a/core/shared/src/main/scala/io/udash/properties/ImmutableProperty.scala
+++ b/core/shared/src/main/scala/io/udash/properties/ImmutableProperty.scala
@@ -1,7 +1,5 @@
 package io.udash.properties
 
-import java.util.UUID
-
 import io.udash.properties.model.{ModelPropertyMacroApi, ReadableModelProperty}
 import io.udash.properties.seq.{Patch, ReadableSeqProperty}
 import io.udash.properties.single.{Property, ReadableProperty}
@@ -13,7 +11,7 @@ private[properties] class ImmutableProperty[A](value: A) extends ReadablePropert
   override type ModelSubProperty[_] = ImmutableProperty[_]
 
   /** Unique property ID. */
-  override val id: UUID = UUID.randomUUID()
+  override val id: PropertyId = PropertyCreator.newID()
 
   /** @return Current property value. */
   @inline override def get: A = value

--- a/core/shared/src/main/scala/io/udash/properties/PropertyCreator.scala
+++ b/core/shared/src/main/scala/io/udash/properties/PropertyCreator.scala
@@ -1,7 +1,5 @@
 package io.udash.properties
 
-import java.util.UUID
-
 import io.udash.properties.seq.DirectSeqPropertyImpl
 import io.udash.properties.single.{CastableProperty, DirectPropertyImpl, ReadableProperty}
 
@@ -24,7 +22,7 @@ object PropertyCreator extends PropertyCreatorImplicits {
   def propertyCreator[T: PropertyCreator]: PropertyCreator[T] =
     implicitly[PropertyCreator[T]]
 
-  def newID(): UUID = UUID.randomUUID()
+  def newID(): PropertyId = PropertyIdGenerator.next()
 }
 
 class SinglePropertyCreator[T] extends PropertyCreator[T] {

--- a/core/shared/src/main/scala/io/udash/properties/PropertyId.scala
+++ b/core/shared/src/main/scala/io/udash/properties/PropertyId.scala
@@ -1,0 +1,4 @@
+package io.udash.properties
+
+/** Platform-unique property ID. */
+final case class PropertyId private(value: Long) extends AnyVal

--- a/core/shared/src/main/scala/io/udash/properties/model/ModelPropertyImpl.scala
+++ b/core/shared/src/main/scala/io/udash/properties/model/ModelPropertyImpl.scala
@@ -1,13 +1,11 @@
 package io.udash.properties
 package model
 
-import java.util.UUID
-
 import io.udash.properties.seq.ReadableSeqProperty
 import io.udash.properties.single.{CastableProperty, Property, ReadableProperty}
 
 
-abstract class ModelPropertyImpl[A](val parent: ReadableProperty[_], override val id: UUID)
+abstract class ModelPropertyImpl[A](val parent: ReadableProperty[_], override val id: PropertyId)
   extends ModelProperty[A] with CastableProperty[A] with ModelPropertyMacroApi[A] {
 
   override type ModelSubProperty[_] = ModelPropertyImpl[_]

--- a/core/shared/src/main/scala/io/udash/properties/seq/DirectSeqPropertyImpl.scala
+++ b/core/shared/src/main/scala/io/udash/properties/seq/DirectSeqPropertyImpl.scala
@@ -1,12 +1,10 @@
 package io.udash.properties.seq
 
-import java.util.UUID
-
-import io.udash.properties.{CrossCollections, MutableBufferRegistration, PropertyCreator}
 import io.udash.properties.single.{CastableProperty, ReadableProperty}
+import io.udash.properties.{CrossCollections, MutableBufferRegistration, PropertyCreator, PropertyId}
 import io.udash.utils.Registration
 
-class DirectSeqPropertyImpl[A : PropertyCreator](val parent: ReadableProperty[_], override val id: UUID)
+class DirectSeqPropertyImpl[A: PropertyCreator](val parent: ReadableProperty[_], override val id: PropertyId)
   extends SeqProperty[A, CastableProperty[A]] with CastableProperty[Seq[A]] {
 
   private val properties = CrossCollections.createArray[CastableProperty[A]]

--- a/core/shared/src/main/scala/io/udash/properties/seq/ReadableSeqProperty.scala
+++ b/core/shared/src/main/scala/io/udash/properties/seq/ReadableSeqProperty.scala
@@ -1,7 +1,5 @@
 package io.udash.properties.seq
 
-import java.util.UUID
-
 import io.udash.properties._
 import io.udash.properties.single.{AbstractReadableProperty, ReadableProperty}
 import io.udash.utils.{Registration, SetRegistration}
@@ -50,7 +48,7 @@ trait ReadableSeqProperty[A, +ElemType <: ReadableProperty[A]] extends ReadableP
     class CombinedReadableSeqProperty(s: ReadableSeqProperty[A, _ <: ReadableProperty[A]], p: ReadableProperty[B])
       extends AbstractReadableSeqProperty[O, ReadableProperty[O]] {
 
-      override val id: UUID = PropertyCreator.newID()
+      override val id: PropertyId = PropertyCreator.newID()
       override protected[properties] val parent: ReadableProperty[_] = null
 
       private val children = CrossCollections.createArray[ReadableProperty[O]]
@@ -109,8 +107,9 @@ trait AbstractReadableSeqProperty[A, +ElemType <: ReadableProperty[A]] extends A
     *
     * @return Validation result as Future, which will be completed on the validation process ending. It can fire validation process if needed. */
   override def isValid: Future[ValidationResult] = {
-    import scala.concurrent.ExecutionContext.Implicits.global
     import Validator._
+
+    import scala.concurrent.ExecutionContext.Implicits.global
 
     if (validationResult == null) {
       validationResult = Future.sequence(Seq(super.isValid) ++ elemProperties.map(p => p.isValid)).foldValidationResult

--- a/core/shared/src/main/scala/io/udash/properties/seq/SeqPropertyFromSingleValue.scala
+++ b/core/shared/src/main/scala/io/udash/properties/seq/SeqPropertyFromSingleValue.scala
@@ -1,8 +1,6 @@
 package io.udash.properties
 package seq
 
-import java.util.UUID
-
 import io.udash.properties.single._
 import io.udash.utils.{Registration, SetRegistration}
 
@@ -14,7 +12,7 @@ abstract class BaseReadableSeqPropertyFromSingleValue[A, B: PropertyCreator](
   transformer: A => Seq[B]
 ) extends AbstractReadableSeqProperty[B, ReadableProperty[B]] {
 
-  override val id: UUID = PropertyCreator.newID()
+  override val id: PropertyId = PropertyCreator.newID()
   override protected[properties] def parent: ReadableProperty[_] = null
 
   protected final val structureListeners: mutable.Set[Patch[Property[B]] => Any] = mutable.Set()

--- a/core/shared/src/main/scala/io/udash/properties/seq/ZippedSeqProperty.scala
+++ b/core/shared/src/main/scala/io/udash/properties/seq/ZippedSeqProperty.scala
@@ -1,16 +1,14 @@
 package io.udash.properties.seq
 
-import java.util.UUID
-
 import io.udash.properties.single.ReadableProperty
-import io.udash.properties.{CallbackSequencer, CrossCollections, PropertyCreator}
+import io.udash.properties.{CallbackSequencer, CrossCollections, PropertyCreator, PropertyId}
 import io.udash.utils.{Registration, SetRegistration}
 
 import scala.collection.mutable
 
 private[properties]
 abstract class ZippedSeqPropertyUtils[O] extends AbstractReadableSeqProperty[O, ReadableProperty[O]] {
-  override val id: UUID = PropertyCreator.newID()
+  override val id: PropertyId = PropertyCreator.newID()
   override protected[properties] val parent: ReadableProperty[_] = null
 
   protected final val children = CrossCollections.createArray[ReadableProperty[O]]

--- a/core/shared/src/main/scala/io/udash/properties/single/DirectPropertyImpl.scala
+++ b/core/shared/src/main/scala/io/udash/properties/single/DirectPropertyImpl.scala
@@ -1,8 +1,8 @@
 package io.udash.properties.single
 
-import java.util.UUID
+import io.udash.properties.PropertyId
 
-class DirectPropertyImpl[A](val parent: ReadableProperty[_], override val id: UUID)
+class DirectPropertyImpl[A](val parent: ReadableProperty[_], override val id: PropertyId)
   extends CastableProperty[A] {
 
   private var value: A = _

--- a/core/shared/src/main/scala/io/udash/properties/single/ForwarderProperty.scala
+++ b/core/shared/src/main/scala/io/udash/properties/single/ForwarderProperty.scala
@@ -1,15 +1,13 @@
 package io.udash.properties.single
 
-import java.util.UUID
-
-import io.udash.properties.{PropertyCreator, ValidationResult}
+import io.udash.properties.{PropertyCreator, PropertyId, ValidationResult}
 
 import scala.concurrent.Future
 
 trait ForwarderReadableProperty[A] extends AbstractReadableProperty[A] {
   protected def origin: ReadableProperty[_]
 
-  override val id: UUID = PropertyCreator.newID()
+  override val id: PropertyId = PropertyCreator.newID()
   override protected[properties] def parent: ReadableProperty[_] = null
 
   override def isValid: Future[ValidationResult] =

--- a/core/shared/src/main/scala/io/udash/properties/single/Property.scala
+++ b/core/shared/src/main/scala/io/udash/properties/single/Property.scala
@@ -136,4 +136,3 @@ trait Property[A] extends AbstractReadableProperty[A] {
 
   }
 }
-

--- a/core/shared/src/main/scala/io/udash/properties/single/ReadableProperty.scala
+++ b/core/shared/src/main/scala/io/udash/properties/single/ReadableProperty.scala
@@ -1,7 +1,5 @@
 package io.udash.properties.single
 
-import java.util.UUID
-
 import io.udash.properties._
 import io.udash.properties.seq.{ReadableSeqProperty, ReadableSeqPropertyFromSingleValue}
 import io.udash.utils.Registration
@@ -12,7 +10,7 @@ import scala.concurrent.{Future, Promise}
 /** Base interface of every Property in Udash. */
 trait ReadableProperty[A] {
   /** Unique property ID. */
-  val id: UUID
+  val id: PropertyId
 
   /** @return Current property value. */
   def get: A


### PR DESCRIPTION
UUIDs can be slow to generate and we don't necesarily need to use random IDs there (especially from a SecureRandom on the JVM side, which is the case, I believe, for that particular `UUID.randomUUID` implementation). 

On my machine, this proved to be quite beneficial for the immutable property binding benchmark (2x improvement). Please verify, it could be a nice addition to your immutable props PR.