### PR TITLE
Callback successful upload

### DIFF
--- a/core/frontend/src/main/scala/io/udash/utils/FileUploader.scala
+++ b/core/frontend/src/main/scala/io/udash/utils/FileUploader.scala
@@ -9,7 +9,6 @@ import scala.scalajs.js
 
 class FileUploader(url: Url) {
   import FileUploader._
-  import FileUploader.FileUploadState.HttpResponse
 
   /** Uploads files selected in provided `input`. */
   def upload(input: html.Input): ReadableModelProperty[FileUploadModel] =
@@ -76,20 +75,6 @@ object FileUploader {
     case object Cancelled extends Done
 
     implicit val blank: Blank[FileUploadState] = Blank.Simple(NotStarted)
-
-    case class HttpResponse(
-      text: Option[String], responseType: Option[String], url: Option[String], xml: Option[Document]
-    )
-
-    object HttpResponse {
-      def apply(xhr: XMLHttpRequest): HttpResponse =
-        new HttpResponse(
-          Option(xhr.responseText),
-          if (xhr.responseType.nonEmpty) Some(xhr.responseType) else None,
-          xhr.responseURL.toOption,
-          Option(xhr.responseXML)
-        )
-    }
   }
 
   class FileUploadModel(

--- a/core/frontend/src/main/scala/io/udash/utils/HttpResponse.scala
+++ b/core/frontend/src/main/scala/io/udash/utils/HttpResponse.scala
@@ -1,0 +1,26 @@
+package io.udash.utils
+
+import com.avsystem.commons.misc.AbstractCase
+import org.scalajs.dom.Document
+import org.scalajs.dom.raw.XMLHttpRequest
+
+sealed trait HttpResponse {
+  def text: Option[String]
+  def responseType: Option[String]
+  def url: Option[String]
+  def xml: Option[Document]
+}
+
+object HttpResponse {
+  private case class HttpResponseImpl(
+    text: Option[String], responseType: Option[String], url: Option[String], xml: Option[Document]
+  ) extends AbstractCase with HttpResponse
+
+  def apply(xhr: XMLHttpRequest): HttpResponse =
+    HttpResponseImpl(
+      Option(xhr.responseText),
+      if (xhr.responseType.nonEmpty) Some(xhr.responseType) else None,
+      xhr.responseURL.toOption,
+      Option(xhr.responseXML)
+    )
+}


### PR DESCRIPTION
At some cases after upload, developed action may require processing HTTP response (e.g. getting uploaded file id from servlet after successful request) 

Considered alternative to callback: `case class Completed(response: HttpResponse)`  in upload state model and setting listener on it. Imho, keeping response every time upload has been completed is undesired.