### PR TITLE
Parameterized URLEncoding with plusAsSpace/spaceAsPlus

### DIFF
--- a/rest/src/test/scala/io/udash/rest/AbstractRestCallTest.scala
+++ b/rest/src/test/scala/io/udash/rest/AbstractRestCallTest.scala
@@ -33,11 +33,11 @@ abstract class AbstractRestCallTest extends FunSuite with ScalaFutures {
   }
 
   test("complex GET") {
-    testCall(_.complexGet(0, "a/+&", 1, "b/+&", 2, "ć/+&"))
+    testCall(_.complexGet(0, "a/ +&", 1, "b/ +&", 2, "ć/ +&"))
   }
 
   test("multi-param body POST") {
-    testCall(_.multiParamPost(0, "a/+&", 1, "b/+&", 2, "ć/+&", 3, "l\"l"))
+    testCall(_.multiParamPost(0, "a/ +&", 1, "b/ +&", 2, "ć/ +&", 3, "l\"l"))
   }
 
   test("single body PUT") {

--- a/selenium/.js/src/main/scala/io/udash/selenium/views/demos/frontend/RoutingLinkDemoComponent.scala
+++ b/selenium/.js/src/main/scala/io/udash/selenium/views/demos/frontend/RoutingLinkDemoComponent.scala
@@ -16,7 +16,7 @@ class RoutingLinkDemoComponent(url: Property[String]) extends CssView {
   private val urlArg = Property("")
   urlArg.listen { value =>
     applicationInstance.goTo(FrontendRoutingDemosState(
-      Some(URLEncoder.encode(value))
+      Some(URLEncoder.encode(value, spaceAsPlus = false))
     ))
   }
 

--- a/selenium/.jvm/src/test/scala/io/udash/selenium/frontend/FrontendRoutingTest.scala
+++ b/selenium/.jvm/src/test/scala/io/udash/selenium/frontend/FrontendRoutingTest.scala
@@ -84,7 +84,7 @@ class FrontendRoutingTest extends SeleniumTest {
         linkChanger.clear()
         linkChanger.sendKeys(s)
         eventually {
-          val escaped = s"/frontend/routing/${URLEncoder.encode(s)}"
+          val escaped = s"/frontend/routing/${URLEncoder.encode(s, spaceAsPlus = false)}"
           val unescaped = s"/frontend/routing/$s"
           init.getText should be("/frontend/routing")
           link.getText should matchPattern {

--- a/utils/.js/src/main/scala/io/udash/utils/URLEncoder.scala
+++ b/utils/.js/src/main/scala/io/udash/utils/URLEncoder.scala
@@ -3,9 +3,19 @@ package io.udash.utils
 import scala.scalajs.js
 
 object URLEncoder {
-  def encode(query: String): String =
-    js.URIUtils.encodeURIComponent(query)
+  def encode(query: String, spaceAsPlus: Boolean): String = {
+    val res = js.URIUtils.encodeURIComponent(query)
+      .replace("!", "%21")
+      .replace("'", "%27")
+      .replace("(", "%28")
+      .replace(")", "%29")
+      .replace("~", "%7E")
 
-  def decode(query: String): String =
-    js.URIUtils.decodeURIComponent(query)
+    if (spaceAsPlus) res.replace("%20", "+") else res
+  }
+
+  def decode(query: String, plusAsSpace: Boolean): String = {
+    val pre = if (plusAsSpace) query.replace("+", "%20") else query
+    js.URIUtils.decodeURIComponent(pre)
+  }
 }

--- a/utils/.jvm/src/main/scala/io/udash/utils/URLEncoder.scala
+++ b/utils/.jvm/src/main/scala/io/udash/utils/URLEncoder.scala
@@ -1,15 +1,13 @@
 package io.udash.utils
 
 object URLEncoder {
-  def encode(query: String): String =
-    java.net.URLEncoder.encode(query, "UTF-8")
-      .replaceAll("\\%28", "(")
-      .replaceAll("\\%29", ")")
-      .replaceAll("\\+", "%20")
-      .replaceAll("\\%27", "'")
-      .replaceAll("\\%21", "!")
-      .replaceAll("\\%7E", "~")
+  def encode(query: String, spaceAsPlus: Boolean): String = {
+    val res = java.net.URLEncoder.encode(query, "UTF-8")
+    if (spaceAsPlus) res else res.replace("+", "%20")
+  }
 
-  def decode(query: String): String =
-    java.net.URLDecoder.decode(query.replaceAll("\\+", "%2B"), "UTF-8")
+  def decode(query: String, plusAsSpace: Boolean): String = {
+    val pre = if (plusAsSpace) query else query.replace("+", "%2B")
+    java.net.URLDecoder.decode(pre, "UTF-8")
+  }
 }

--- a/utils/src/test/scala/io/udash/utils/URLEncoderTest.scala
+++ b/utils/src/test/scala/io/udash/utils/URLEncoderTest.scala
@@ -8,8 +8,14 @@ class URLEncoderTest extends UdashSharedTest {
   "URLEncoder" should {
     "encode and decode data in the same way for both JVM and JS" in {
       val data = "a b »~!@#$%^&*()_+=-`{}[]:\";'<>?/.,♦"
-      URLEncoder.encode(data) should be("a%20b%20%C2%BB~!%40%23%24%25%5E%26*()_%2B%3D-%60%7B%7D%5B%5D%3A%22%3B'%3C%3E%3F%2F.%2C%E2%99%A6")
-      URLEncoder.decode(URLEncoder.encode(data)) should be(data)
+
+      URLEncoder.encode(data, spaceAsPlus = true) should
+        be("a+b+%C2%BB%7E%21%40%23%24%25%5E%26*%28%29_%2B%3D-%60%7B%7D%5B%5D%3A%22%3B%27%3C%3E%3F%2F.%2C%E2%99%A6")
+      URLEncoder.decode(URLEncoder.encode(data, spaceAsPlus = true), plusAsSpace = true) should be(data)
+
+      URLEncoder.encode(data, spaceAsPlus = false) should
+        be("a%20b%20%C2%BB%7E%21%40%23%24%25%5E%26*%28%29_%2B%3D-%60%7B%7D%5B%5D%3A%22%3B%27%3C%3E%3F%2F.%2C%E2%99%A6")
+      URLEncoder.decode(URLEncoder.encode(data, spaceAsPlus = false), plusAsSpace = false) should be(data)
     }
   }
 


### PR DESCRIPTION
Udash `URLEncoder` is now as close to JVM's `URLEncoder/URLDecoder` as possible but with additional option to choose if spaces are encoded as `+`.

This is primarily to match the way `sttp` does its encoding - space is encoded as `+` in query parameters, but apparently in path segments it isn't...