### PR TITLE
Fixed error handling for bad REST requests

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   val scalaCssVersion = "0.5.5"
 
   val servletVersion = "3.1.0"
-  val avsCommonsVersion = "1.34.0"
+  val avsCommonsVersion = "1.34.1"
 
   val atmosphereJSVersion = "2.3.6"
   val atmosphereVersion = "2.4.30"
@@ -69,9 +69,9 @@ object Dependencies {
   private val coreCrossDeps = Def.setting(Seq(
     "com.lihaoyi" %%% "scalatags" % scalaTagsVersion
   ))
-  
+
   val coreJvmDeps = coreCrossDeps
-  
+
   val coreSjsDeps = coreCrossDeps
 
   private val rpcCrossDeps = Def.setting(Seq(

--- a/rest/src/main/scala/io/udash/rest/raw/RawRest.scala
+++ b/rest/src/main/scala/io/udash/rest/raw/RawRest.scala
@@ -7,7 +7,6 @@ import java.util.concurrent.atomic.AtomicBoolean
 import com.avsystem.commons._
 import com.avsystem.commons.meta._
 import com.avsystem.commons.rpc._
-import com.avsystem.commons.serialization.GenCodec.ReadFailure
 
 sealed abstract class RestMethodCall {
   val pathParams: List[PathValue]
@@ -73,7 +72,7 @@ trait RawRest {
     val HttpCall(finalPathParams, finalMetadata) = finalCall
 
     def handleBadBody[T](expr: => T): T = try expr catch {
-      case rf: ReadFailure => throw new InvalidRpcCall(s"Invalid HTTP body: ${rf.getMessage}", rf)
+      case NonFatal(cause) => throw new InvalidRpcCall(s"Invalid HTTP body: ${cause.getMessage}", cause)
     }
 
     def resolveCall(rawRest: RawRest, prefixes: List[PrefixCall]): Async[RestResponse] = prefixes match {


### PR DESCRIPTION
This PR makes sure that invalid JSON bodies trigger `400 Bad Request` instead of `500 Internal Server Error` and also improves error messages for bad requests.