### PR TITLE
SttpRestClient with implicit SttpBackend parameter

### DIFF
--- a/docs/REST.md
+++ b/docs/REST.md
@@ -125,10 +125,11 @@ object ServerMain {
 
 ```
 
-Finally, obtain a client proxy for your API using Jetty HTTP client and make a call:
+Finally, obtain a client proxy for your API using STTP and make a call:
 
 ```scala
-import io.udash.rest.DefaultRestClient
+import com.softwaremill.sttp.SttpBackend
+import io.udash.rest.SttpRestClient
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
@@ -136,11 +137,13 @@ import scala.util.{Failure, Success}
 
 object ClientMain {
   def main(args: Array[String]): Unit = {
-    val proxy: UserApi = DefaultRestClient[UserApi]("http://localhost:9090/")
+    implicit val sttpBackend: SttpBackend[Future, Nothing] = SttpRestClient.defaultBackend()
+    val proxy: UserApi = SttpRestClient[UserApi]("http://localhost:9090/")
 
+    // make a remote REST call
     val result: Future[User] = proxy.createUser("Fred", 1990)
 
-    // just for this example, normally it's not recommended
+    // use whatever execution context is appropriate
     import scala.concurrent.ExecutionContext.Implicits.global
 
     result.onComplete {

--- a/rest/.js/src/main/scala/io/udash/rest/DefaultSttpBackend.scala
+++ b/rest/.js/src/main/scala/io/udash/rest/DefaultSttpBackend.scala
@@ -5,6 +5,6 @@ import com.softwaremill.sttp.{FetchBackend, SttpBackend}
 
 import scala.concurrent.Future
 
-private[rest] object DefaultSttpBackend {
-  implicit val backend: SttpBackend[Future, Nothing] = FetchBackend()
+object DefaultSttpBackend {
+  def apply(): SttpBackend[Future, Nothing] = FetchBackend()
 }

--- a/rest/.jvm/src/main/scala/io/udash/rest/DefaultSttpBackend.scala
+++ b/rest/.jvm/src/main/scala/io/udash/rest/DefaultSttpBackend.scala
@@ -6,6 +6,6 @@ import com.softwaremill.sttp.asynchttpclient.future.AsyncHttpClientFutureBackend
 
 import scala.concurrent.Future
 
-private[udash] object DefaultSttpBackend {
-  implicit val backend: SttpBackend[Future, Nothing] = AsyncHttpClientFutureBackend()
+object DefaultSttpBackend {
+  def apply(): SttpBackend[Future, Nothing] = AsyncHttpClientFutureBackend()
 }

--- a/rest/.jvm/src/test/scala/io/udash/rest/EndpointsIntegrationTest.scala
+++ b/rest/.jvm/src/test/scala/io/udash/rest/EndpointsIntegrationTest.scala
@@ -4,6 +4,8 @@ package rest
 import java.net.ConnectException
 
 import com.avsystem.commons.meta.Mapping
+import com.softwaremill.sttp.SttpBackend
+import io.udash.rest.raw._
 import io.udash.testing.UdashSharedTest
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.gzip.GzipHandler
@@ -12,7 +14,6 @@ import org.eclipse.jetty.servlet.{ServletContextHandler, ServletHolder}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.time.{Millis, Seconds, Span}
-import io.udash.rest.raw._
 
 import scala.concurrent.duration.DurationLong
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -59,9 +60,11 @@ class EndpointsIntegrationTest extends UdashSharedTest with BeforeAndAfterAll wi
     HttpBody.json(JsonValue(body))
   )
 
-  val rawHandler = futureHandle(DefaultRestClient.asHandleRequest(baseUri))
-  val proxy: TestServerRESTInterface = DefaultRestClient[TestServerRESTInterface](baseUri)
-  val badRawHandler = futureHandle(DefaultRestClient.asHandleRequest(s"http://127.0.0.1:69$contextPrefix"))
+  implicit val backend: SttpBackend[Future, Nothing] = SttpRestClient.defaultBackend()
+
+  val rawHandler = futureHandle(SttpRestClient.asHandleRequest(baseUri))
+  val proxy: TestServerRESTInterface = SttpRestClient[TestServerRESTInterface](baseUri)
+  val badRawHandler = futureHandle(SttpRestClient.asHandleRequest(s"http://127.0.0.1:69$contextPrefix"))
 
   def await[T](f: Future[T]): T =
     Await.result(f, 3 seconds)

--- a/rest/.jvm/src/test/scala/io/udash/rest/HttpRestCallTest.scala
+++ b/rest/.jvm/src/test/scala/io/udash/rest/HttpRestCallTest.scala
@@ -1,14 +1,18 @@
 package io.udash
 package rest
 
+import com.softwaremill.sttp.SttpBackend
 import io.udash.rest.raw.RawRest.HandleRequest
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.servlet.{ServletHandler, ServletHolder}
 
+import scala.concurrent.Future
 import scala.concurrent.duration._
 
 class HttpRestCallTest extends AbstractRestCallTest with UsesHttpServer {
   override def patienceConfig: PatienceConfig = PatienceConfig(10.seconds)
+
+  implicit val backend: SttpBackend[Future, Nothing] = SttpRestClient.defaultBackend()
 
   protected def setupServer(server: Server): Unit = {
     val servlet = new RestServlet(serverHandle)
@@ -19,5 +23,5 @@ class HttpRestCallTest extends AbstractRestCallTest with UsesHttpServer {
   }
 
   def clientHandle: HandleRequest =
-    DefaultRestClient.asHandleRequest(s"$baseUrl/api")
+    SttpRestClient.asHandleRequest(s"$baseUrl/api")
 }

--- a/rest/.jvm/src/test/scala/io/udash/rest/examples/ClientMain.scala
+++ b/rest/.jvm/src/test/scala/io/udash/rest/examples/ClientMain.scala
@@ -1,7 +1,8 @@
 package io.udash
 package rest.examples
 
-import io.udash.rest.DefaultRestClient
+import com.softwaremill.sttp.SttpBackend
+import io.udash.rest.SttpRestClient
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
@@ -9,11 +10,13 @@ import scala.util.{Failure, Success}
 
 object ClientMain {
   def main(args: Array[String]): Unit = {
-    val proxy: UserApi = DefaultRestClient[UserApi]("http://localhost:9090/")
+    implicit val sttpBackend: SttpBackend[Future, Nothing] = SttpRestClient.defaultBackend()
+    val proxy: UserApi = SttpRestClient[UserApi]("http://localhost:9090/")
 
+    // make a remote REST call
     val result: Future[User] = proxy.createUser("Fred", 1990)
 
-    // just for this example, normally it's not recommended
+    // use whatever execution context is appropriate
     import scala.concurrent.ExecutionContext.Implicits.global
 
     result.onComplete {

--- a/rest/src/main/scala/io/udash/rest/SttpRestClient.scala
+++ b/rest/src/main/scala/io/udash/rest/SttpRestClient.scala
@@ -12,7 +12,7 @@ import io.udash.rest.raw._
 import scala.concurrent.Future
 
 object SttpRestClient {
-  def defaultBackend(): SttpBackend[Future, Nothing] = SttpRestClient.defaultBackend()
+  def defaultBackend(): SttpBackend[Future, Nothing] = DefaultSttpBackend()
 
   @explicitGenerics def apply[RestApi: RawRest.AsRealRpc : RestMetadata](baseUri: String)(
     implicit backend: SttpBackend[Future, Nothing]

--- a/rest/src/main/scala/io/udash/rest/SttpRestClient.scala
+++ b/rest/src/main/scala/io/udash/rest/SttpRestClient.scala
@@ -7,18 +7,23 @@ import com.avsystem.commons.meta.Mapping
 import com.softwaremill.sttp.Uri.QueryFragment.KeyValue
 import com.softwaremill.sttp.Uri.QueryFragmentEncoding
 import com.softwaremill.sttp._
-import io.udash.rest.DefaultSttpBackend.backend
 import io.udash.rest.raw._
 
-object DefaultRestClient {
-  @explicitGenerics def apply[RestApi: RawRest.AsRealRpc : RestMetadata](baseUri: String): RestApi =
+import scala.concurrent.Future
+
+object SttpRestClient {
+  def defaultBackend(): SttpBackend[Future, Nothing] = SttpRestClient.defaultBackend()
+
+  @explicitGenerics def apply[RestApi: RawRest.AsRealRpc : RestMetadata](baseUri: String)(
+    implicit backend: SttpBackend[Future, Nothing]
+  ): RestApi =
     RawRest.fromHandleRequest[RestApi](asHandleRequest(baseUri))
 
   /**
     * Creates a [[io.udash.rest.raw.RawRest.HandleRequest HandleRequest]] function which sends REST requests to
     * a specified base URI using default HTTP client implementation (sttp).
     */
-  def asHandleRequest(baseUri: String): RawRest.HandleRequest =
+  def asHandleRequest(baseUri: String)(implicit backend: SttpBackend[Future, Nothing]): RawRest.HandleRequest =
     asHandleRequest(uri"$baseUri")
 
   private def toSttpRequest(baseUri: Uri, request: RestRequest): Request[String, Nothing] = {
@@ -61,7 +66,7 @@ object DefaultRestClient {
       }
     )
 
-  private def asHandleRequest(baseUri: Uri): RawRest.HandleRequest =
+  private def asHandleRequest(baseUri: Uri)(implicit backend: SttpBackend[Future, Nothing]): RawRest.HandleRequest =
     RawRest.safeHandle(request => {
       val sttpReq = toSttpRequest(baseUri, request)
       callback =>

--- a/selenium/.js/src/main/scala/io/udash/selenium/Launcher.scala
+++ b/selenium/.js/src/main/scala/io/udash/selenium/Launcher.scala
@@ -1,7 +1,8 @@
 package io.udash.selenium
 
+import com.softwaremill.sttp.SttpBackend
 import io.udash.Application
-import io.udash.rest.DefaultRestClient
+import io.udash.rest.SttpRestClient
 import io.udash.routing.{UrlLogging, WindowUrlPathChangeProvider}
 import io.udash.rpc.DefaultServerRPC
 import io.udash.selenium.routing.{RoutingRegistryDef, RoutingState, StatesToViewFactoryDef}
@@ -12,7 +13,7 @@ import io.udash.wrappers.jquery.jQ
 import org.scalajs.dom
 import org.scalajs.dom.Element
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 import scala.scalajs.js.annotation.JSExport
 import scala.util.Try
 
@@ -30,11 +31,13 @@ object Launcher {
   val serverRpc: MainServerRPC =
     DefaultServerRPC[MainClientRPC, MainServerRPC](new RPCService, exceptionsRegistry = GuideExceptions.registry)
 
+  implicit val backend: SttpBackend[Future, Nothing] = SttpRestClient.defaultBackend()
+
   val restServer: MainServerREST = {
     val (scheme, defaultPort) =
       if (dom.window.location.protocol == "https:") ("https", 443) else ("http", 80)
     val port = Try(dom.window.location.port.toInt).getOrElse(defaultPort)
-    DefaultRestClient[MainServerREST](s"$scheme://${dom.window.location.hostname}:$port/rest_api")
+    SttpRestClient[MainServerREST](s"$scheme://${dom.window.location.hostname}:$port/rest_api")
   }
 
   @JSExport


### PR DESCRIPTION
SttpBackend must be accepted from outside because it potentially holds network resources which must be released. Accepting SttpBackend as implicit parameter effectively makes it clear that DefaultRestBackend is an STTP-based one, so renaming it appropriately.