### PR TITLE
Better sealed schemas

### DIFF
--- a/rest/src/main/scala/io/udash/rest/RestDataCompanion.scala
+++ b/rest/src/main/scala/io/udash/rest/RestDataCompanion.scala
@@ -26,5 +26,5 @@ abstract class RestDataCompanion[T](implicit
 ) extends {
   implicit lazy val codec: GenCodec[T] = instances(DefaultRestImplicits, this).codec
   implicit lazy val restStructure: RestStructure[T] = instances(DefaultRestImplicits, this).structure
-  implicit lazy val restSchema: RestSchema[T] = RestSchema.lazySchema(restStructure.standaloneSchema)
+  implicit lazy val restSchema: RestSchema[T] = RestSchema.lazySchema(restStructure.restSchema)
 }

--- a/rest/src/test/scala/io/udash/rest/RestTestApi.scala
+++ b/rest/src/test/scala/io/udash/rest/RestTestApi.scala
@@ -4,7 +4,7 @@ package rest
 import com.avsystem.commons._
 import com.avsystem.commons.meta.Mapping
 import com.avsystem.commons.rpc.AsRawReal
-import com.avsystem.commons.serialization.{flatten, whenAbsent}
+import com.avsystem.commons.serialization.{defaultCase, flatten, whenAbsent}
 import io.udash.rest.openapi.adjusters._
 import io.udash.rest.openapi.{Header => OASHeader, _}
 import io.udash.rest.raw._
@@ -16,7 +16,7 @@ object BaseEntity extends RestDataCompanion[BaseEntity]
 @flatten sealed trait FlatBaseEntity extends BaseEntity
 object FlatBaseEntity extends RestDataCompanion[FlatBaseEntity]
 
-@description("REST entity")
+@defaultCase @description("REST entity")
 case class RestEntity(
   @description("entity id") id: String,
   @whenAbsent("anonymous") name: String = whenAbsent.value,

--- a/rest/src/test/scala/io/udash/rest/openapi/OpenApiGenerationTest.scala
+++ b/rest/src/test/scala/io/udash/rest/openapi/OpenApiGenerationTest.scala
@@ -486,7 +486,6 @@ class OpenApiGenerationTest extends FunSuite {
         |  "components": {
         |    "schemas": {
         |      "BaseEntity": {
-        |        "type": "object",
         |        "oneOf": [
         |          {
         |            "type": "object",
@@ -503,22 +502,7 @@ class OpenApiGenerationTest extends FunSuite {
         |            "type": "object",
         |            "properties": {
         |              "RestOtherEntity": {
-        |                "type": "object",
-        |                "properties": {
-        |                  "fuu": {
-        |                    "type": "boolean"
-        |                  },
-        |                  "kek": {
-        |                    "type": "array",
-        |                    "items": {
-        |                      "type": "string"
-        |                    }
-        |                  }
-        |                },
-        |                "required": [
-        |                  "fuu",
-        |                  "kek"
-        |                ]
+        |                "$ref": "#/components/schemas/RestOtherEntity"
         |              }
         |            },
         |            "required": [
@@ -529,7 +513,7 @@ class OpenApiGenerationTest extends FunSuite {
         |            "type": "object",
         |            "properties": {
         |              "SingletonEntity": {
-        |                "type": "object"
+        |                "$ref": "#/components/schemas/SingletonEntity"
         |              }
         |            },
         |            "required": [
@@ -539,11 +523,10 @@ class OpenApiGenerationTest extends FunSuite {
         |        ]
         |      },
         |      "FlatBaseEntity": {
-        |        "type": "object",
         |        "description": "Flat sealed entity with some serious cases",
         |        "oneOf": [
         |          {
-        |            "$ref": "#/components/schemas/taggedRestEntity"
+        |            "$ref": "#/components/schemas/RestEntity"
         |          },
         |          {
         |            "$ref": "#/components/schemas/RestOtherEntity"
@@ -553,12 +536,7 @@ class OpenApiGenerationTest extends FunSuite {
         |          }
         |        ],
         |        "discriminator": {
-        |          "propertyName": "_case",
-        |          "mapping": {
-        |            "RestEntity": "#/components/schemas/taggedRestEntity",
-        |            "RestOtherEntity": "#/components/schemas/RestOtherEntity",
-        |            "SingletonEntity": "#/components/schemas/SingletonEntity"
-        |          }
+        |          "propertyName": "_case"
         |        }
         |      },
         |      "RestEntity": {
@@ -591,12 +569,6 @@ class OpenApiGenerationTest extends FunSuite {
         |      "RestOtherEntity": {
         |        "type": "object",
         |        "properties": {
-        |          "_case": {
-        |            "type": "string",
-        |            "enum": [
-        |              "RestOtherEntity"
-        |            ]
-        |          },
         |          "fuu": {
         |            "type": "boolean"
         |          },
@@ -608,45 +580,12 @@ class OpenApiGenerationTest extends FunSuite {
         |          }
         |        },
         |        "required": [
-        |          "_case",
         |          "fuu",
         |          "kek"
         |        ]
         |      },
         |      "SingletonEntity": {
-        |        "type": "object",
-        |        "properties": {
-        |          "_case": {
-        |            "type": "string",
-        |            "enum": [
-        |              "SingletonEntity"
-        |            ]
-        |          }
-        |        },
-        |        "required": [
-        |          "_case"
-        |        ]
-        |      },
-        |      "taggedRestEntity": {
-        |        "allOf": [
-        |          {
-        |            "type": "object",
-        |            "properties": {
-        |              "_case": {
-        |                "type": "string",
-        |                "enum": [
-        |                  "RestEntity"
-        |                ]
-        |              }
-        |            },
-        |            "required": [
-        |              "_case"
-        |            ]
-        |          },
-        |          {
-        |            "$ref": "#/components/schemas/RestEntity"
-        |          }
-        |        ]
+        |        "type": "object"
         |      }
         |    }
         |  }

--- a/rest/src/test/scala/io/udash/rest/openapi/OpenApiGenerationTest.scala
+++ b/rest/src/test/scala/io/udash/rest/openapi/OpenApiGenerationTest.scala
@@ -524,20 +524,38 @@ class OpenApiGenerationTest extends FunSuite {
         |      },
         |      "FlatBaseEntity": {
         |        "description": "Flat sealed entity with some serious cases",
-        |        "oneOf": [
+        |        "allOf": [
         |          {
-        |            "$ref": "#/components/schemas/RestEntity"
+        |            "type": "object",
+        |            "properties": {
+        |              "_case": {
+        |                "type": "string",
+        |                "enum": [
+        |                  "RestEntity",
+        |                  "RestOtherEntity",
+        |                  "SingletonEntity"
+        |                ],
+        |                "default": "RestEntity"
+        |              }
+        |            }
         |          },
         |          {
-        |            "$ref": "#/components/schemas/RestOtherEntity"
-        |          },
-        |          {
-        |            "$ref": "#/components/schemas/SingletonEntity"
+        |            "oneOf": [
+        |              {
+        |                "$ref": "#/components/schemas/RestEntity"
+        |              },
+        |              {
+        |                "$ref": "#/components/schemas/RestOtherEntity"
+        |              },
+        |              {
+        |                "$ref": "#/components/schemas/SingletonEntity"
+        |              }
+        |            ],
+        |            "discriminator": {
+        |              "propertyName": "_case"
+        |            }
         |          }
-        |        ],
-        |        "discriminator": {
-        |          "propertyName": "_case"
-        |        }
+        |        ]
         |      },
         |      "RestEntity": {
         |        "type": "object",

--- a/rest/src/test/scala/io/udash/rest/openapi/RestSchemaTest.scala
+++ b/rest/src/test/scala/io/udash/rest/openapi/RestSchemaTest.scala
@@ -213,29 +213,51 @@ class RestSchemaTest extends FunSuite {
     assert(schemasStr[FlatBase] ==
       """{
         |  "FlatBase": {
-        |    "oneOf": [
+        |    "allOf": [
         |      {
-        |        "$ref": "#/components/schemas/PlainCase"
+        |        "type": "object",
+        |        "properties": {
+        |          "_case": {
+        |            "type": "string",
+        |            "enum": [
+        |              "PlainCase",
+        |              "SpecializedCase",
+        |              "ExternalCase",
+        |              "UnnamedCase",
+        |              "SingletonCase"
+        |            ]
+        |          }
+        |        },
+        |        "required": [
+        |          "_case"
+        |        ]
         |      },
         |      {
-        |        "$ref": "#/components/schemas/SpecializedCase"
-        |      },
-        |      {
-        |        "$ref": "external.json"
-        |      },
-        |      {
-        |        "$ref": "#/components/schemas/UnnamedCase"
-        |      },
-        |      {
-        |        "$ref": "#/components/schemas/SingletonCase"
+        |        "oneOf": [
+        |          {
+        |            "$ref": "#/components/schemas/PlainCase"
+        |          },
+        |          {
+        |            "$ref": "#/components/schemas/SpecializedCase"
+        |          },
+        |          {
+        |            "$ref": "external.json"
+        |          },
+        |          {
+        |            "$ref": "#/components/schemas/UnnamedCase"
+        |          },
+        |          {
+        |            "$ref": "#/components/schemas/SingletonCase"
+        |          }
+        |        ],
+        |        "discriminator": {
+        |          "propertyName": "_case",
+        |          "mapping": {
+        |            "ExternalCase": "external.json"
+        |          }
+        |        }
         |      }
-        |    ],
-        |    "discriminator": {
-        |      "propertyName": "_case",
-        |      "mapping": {
-        |        "ExternalCase": "external.json"
-        |      }
-        |    }
+        |    ]
         |  },
         |  "PlainCase": {
         |    "type": "object",

--- a/rest/src/test/scala/io/udash/rest/openapi/openapiDependencies.scala
+++ b/rest/src/test/scala/io/udash/rest/openapi/openapiDependencies.scala
@@ -23,7 +23,7 @@ abstract class I18NRestDataCompanion[T](
 ) {
   implicit lazy val codec: GenCodec[T] = instances(DefaultRestImplicits, this).codec
   implicit def restSchema(implicit i18N: I18N): RestSchema[T] =
-    RestSchema.lazySchema(instances(DefaultRestImplicits, this).structure.standaloneSchema)
+    RestSchema.lazySchema(instances(DefaultRestImplicits, this).structure.restSchema)
 }
 
 trait I18NOpenApiFullInstances[Real] extends FullInstances[Real] {


### PR DESCRIPTION
`RestSchema` for sealed hierarchies is now simpler and closer to the [canonical example](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#discriminator-object).

Since discriminator field is not required by specification or at least Swagger UI does not bother to show it, current representation is additionally enhanced with schema for the discriminator field itself, e.g.

```scala
@description("Flat sealed entity with some serious cases")
@flatten sealed trait FlatBaseEntity
object FlatBaseEntity extends RestDataCompanion[FlatBaseEntity]

@defaultCase @description("REST entity")
case class RestEntity(
  @description("entity id") id: String,
  @whenAbsent("anonymous") name: String = whenAbsent.value,
  @description("recursive optional subentity") subentity: OptArg[RestEntity] = OptArg.Empty
) extends FlatBaseEntity
object RestEntity extends RestDataCompanion[RestEntity]

case class RestOtherEntity(fuu: Boolean, kek: List[String]) extends FlatBaseEntity

case object SingletonEntity extends FlatBaseEntity
```

Would be translated into:

```json
"FlatBaseEntity": {
  "description": "Flat sealed entity with some serious cases",
  "allOf": [
    {
      "type": "object",
      "properties": {
        "_case": {
          "type": "string",
          "enum": [
            "RestEntity",
            "RestOtherEntity",
            "SingletonEntity"
          ],
          "default": "RestEntity"
        }
      }
    },
    {
      "oneOf": [
        {
          "$ref": "#/components/schemas/RestEntity"
        },
        {
          "$ref": "#/components/schemas/RestOtherEntity"
        },
        {
          "$ref": "#/components/schemas/SingletonEntity"
        }
      ],
      "discriminator": {
        "propertyName": "_case"
      }
    }
  ]
},
"RestEntity": {
  "type": "object",
  "description": "REST entity",
  "properties": {
    "id": {
      "type": "string",
      "description": "entity id"
    },
    "name": {
      "type": "string",
      "default": "anonymous"
    },
    "subentity": {
      "description": "recursive optional subentity",
      "nullable": true,
      "allOf": [
        {
          "$ref": "#/components/schemas/RestEntity"
        }
      ],
      "default": null
    }
  },
  "required": [
    "id"
  ]
},
"RestOtherEntity": {
  "type": "object",
  "properties": {
    "fuu": {
      "type": "boolean"
    },
    "kek": {
      "type": "array",
      "items": {
        "type": "string"
      }
    }
  },
  "required": [
    "fuu",
    "kek"
  ]
},
"SingletonEntity": {
  "type": "object"
}
```