### PR TITLE
Seq subProp regressions fix

### DIFF
--- a/core/src/main/scala/io/udash/properties/PropertyCreator.scala
+++ b/core/src/main/scala/io/udash/properties/PropertyCreator.scala
@@ -4,6 +4,7 @@ import io.udash.properties.seq.DirectSeqPropertyImpl
 import io.udash.properties.single.{CastableProperty, DirectPropertyImpl, ReadableProperty}
 
 import scala.annotation.implicitNotFound
+import scala.collection.generic.CanBuildFrom
 
 trait PropertyCreator[T] {
   def newProperty(parent: ReadableProperty[_])(implicit blank: Blank[T]): CastableProperty[T] =
@@ -41,12 +42,14 @@ class SinglePropertyCreator[T] extends PropertyCreator[T] {
     new DirectPropertyImpl[T](prt, PropertyCreator.newID())
 }
 
-class SeqPropertyCreator[T : PropertyCreator] extends PropertyCreator[Seq[T]] {
-  protected def create(prt: ReadableProperty[_]): CastableProperty[Seq[T]] =
-    new DirectSeqPropertyImpl[T](prt, PropertyCreator.newID())
+class SeqPropertyCreator[T: PropertyCreator, SeqTpe[T] <: Seq[T]](implicit cbf: CanBuildFrom[Nothing, T, SeqTpe[T]])
+  extends PropertyCreator[SeqTpe[T]] {
+  protected def create(prt: ReadableProperty[_]): CastableProperty[SeqTpe[T]] =
+    new DirectSeqPropertyImpl[T, SeqTpe](prt, PropertyCreator.newID()).asInstanceOf[CastableProperty[SeqTpe[T]]]
 }
 object SeqPropertyCreator {
-  implicit def materializeSeq[T: PropertyCreator]: SeqPropertyCreator[T] = new SeqPropertyCreator[T]
+  implicit def materializeSeq[T: PropertyCreator, SeqTpe[T] <: Seq[T]](implicit cbf: CanBuildFrom[Nothing, T, SeqTpe[T]]): SeqPropertyCreator[T, SeqTpe] =
+    new SeqPropertyCreator[T, SeqTpe]
 }
 
 @implicitNotFound("Class ${T} cannot be used as ModelProperty template. Add `extends HasModelPropertyCreator[${T}]` to companion object of ${T}.")

--- a/core/src/main/scala/io/udash/properties/PropertyCreator.scala
+++ b/core/src/main/scala/io/udash/properties/PropertyCreator.scala
@@ -49,8 +49,9 @@ final class SeqPropertyCreator[T: PropertyCreator, SeqTpe[T] <: Seq[T]](implicit
 }
 
 object SeqPropertyCreator {
-  implicit def materializeSeq[T: PropertyCreator, SeqTpe[T] <: Seq[T]](implicit cbf: CanBuildFrom[Nothing, T, SeqTpe[T]]): SeqPropertyCreator[T, SeqTpe] =
-  macro io.udash.macros.PropertyMacros.reifySeqPropertyCreator[T, SeqTpe]
+  implicit def materializeSeq[T: PropertyCreator, SeqTpe[T] <: Seq[T]](
+    implicit cbf: CanBuildFrom[Nothing, T, SeqTpe[T]]
+  ): SeqPropertyCreator[T, SeqTpe] = macro io.udash.macros.PropertyMacros.reifySeqPropertyCreator[T, SeqTpe]
 }
 
 @implicitNotFound("Class ${T} cannot be used as ModelProperty template. Add `extends HasModelPropertyCreator[${T}]` to companion object of ${T}.")

--- a/core/src/main/scala/io/udash/properties/PropertyCreator.scala
+++ b/core/src/main/scala/io/udash/properties/PropertyCreator.scala
@@ -45,6 +45,9 @@ class SeqPropertyCreator[T : PropertyCreator] extends PropertyCreator[Seq[T]] {
   protected def create(prt: ReadableProperty[_]): CastableProperty[Seq[T]] =
     new DirectSeqPropertyImpl[T](prt, PropertyCreator.newID())
 }
+object SeqPropertyCreator {
+  implicit def materializeSeq[T: PropertyCreator]: SeqPropertyCreator[T] = new SeqPropertyCreator[T]
+}
 
 @implicitNotFound("Class ${T} cannot be used as ModelProperty template. Add `extends HasModelPropertyCreator[${T}]` to companion object of ${T}.")
 abstract class ModelPropertyCreator[T] extends PropertyCreator[T]

--- a/core/src/main/scala/io/udash/properties/PropertyCreator.scala
+++ b/core/src/main/scala/io/udash/properties/PropertyCreator.scala
@@ -37,19 +37,20 @@ object PropertyCreator extends PropertyCreatorImplicits {
   implicit val String: PropertyCreator[String] = new SinglePropertyCreator[String]
 }
 
-class SinglePropertyCreator[T] extends PropertyCreator[T] {
+final class SinglePropertyCreator[T] extends PropertyCreator[T] {
   protected def create(prt: ReadableProperty[_]): CastableProperty[T] =
     new DirectPropertyImpl[T](prt, PropertyCreator.newID())
 }
 
-class SeqPropertyCreator[T: PropertyCreator, SeqTpe[T] <: Seq[T]](implicit cbf: CanBuildFrom[Nothing, T, SeqTpe[T]])
+final class SeqPropertyCreator[T: PropertyCreator, SeqTpe[T] <: Seq[T]](implicit cbf: CanBuildFrom[Nothing, T, SeqTpe[T]])
   extends PropertyCreator[SeqTpe[T]] {
   protected def create(prt: ReadableProperty[_]): CastableProperty[SeqTpe[T]] =
     new DirectSeqPropertyImpl[T, SeqTpe](prt, PropertyCreator.newID()).asInstanceOf[CastableProperty[SeqTpe[T]]]
 }
+
 object SeqPropertyCreator {
   implicit def materializeSeq[T: PropertyCreator, SeqTpe[T] <: Seq[T]](implicit cbf: CanBuildFrom[Nothing, T, SeqTpe[T]]): SeqPropertyCreator[T, SeqTpe] =
-    new SeqPropertyCreator[T, SeqTpe]
+  macro io.udash.macros.PropertyMacros.reifySeqPropertyCreator[T, SeqTpe]
 }
 
 @implicitNotFound("Class ${T} cannot be used as ModelProperty template. Add `extends HasModelPropertyCreator[${T}]` to companion object of ${T}.")

--- a/core/src/main/scala/io/udash/properties/PropertyCreatorImplicits.scala
+++ b/core/src/main/scala/io/udash/properties/PropertyCreatorImplicits.scala
@@ -1,9 +1,5 @@
 package io.udash.properties
 
-trait PropertyCreatorImplicitsLow { this: PropertyCreator.type =>
+trait PropertyCreatorImplicits { this: PropertyCreator.type =>
   implicit def materializeSingle[T]: PropertyCreator[T] = new SinglePropertyCreator[T]
-}
-
-trait PropertyCreatorImplicits extends PropertyCreatorImplicitsLow { this: PropertyCreator.type =>
-  implicit def materializeSeq[T: PropertyCreator]: SeqPropertyCreator[T] = new SeqPropertyCreator[T]
 }

--- a/core/src/main/scala/io/udash/properties/model/ModelProperty.scala
+++ b/core/src/main/scala/io/udash/properties/model/ModelProperty.scala
@@ -27,7 +27,7 @@ trait ModelProperty[A] extends AbstractReadableModelProperty[A] with AbstractPro
   /** Returns child DirectSeqProperty[B] of any Seq-like field. Note that due to SeqProperty mutable nature,
     * there may be performance overhead while calling subSeq on fields of type more specific than scala.collection.Seq,
     * e.g. scala.collection.immutable.List or scala.collection.immutable.Seq */
-  def subSeq[B](f: A => Seq[B])(implicit ev: SeqPropertyCreator[B]): SeqProperty[B, CastableProperty[B]] =
+  def subSeq[B](f: A => Seq[B])(implicit ev: SeqPropertyCreator[B, Seq]): SeqProperty[B, CastableProperty[B]] =
     macro io.udash.macros.PropertyMacros.reifySubSeq[A, B]
 }
 

--- a/core/src/main/scala/io/udash/properties/model/ModelProperty.scala
+++ b/core/src/main/scala/io/udash/properties/model/ModelProperty.scala
@@ -4,6 +4,8 @@ import io.udash.properties._
 import io.udash.properties.seq.SeqProperty
 import io.udash.properties.single._
 
+import scala.collection.generic.CanBuildFrom
+
 object ModelProperty {
   /** Creates a blank ModelProperty[T].  */
   def blank[T: ModelPropertyCreator : Blank]: ModelProperty[T] =
@@ -27,7 +29,8 @@ trait ModelProperty[A] extends AbstractReadableModelProperty[A] with AbstractPro
   /** Returns child DirectSeqProperty[B] of any Seq-like field. Note that due to SeqProperty mutable nature,
     * there may be performance overhead while calling subSeq on fields of type more specific than scala.collection.Seq,
     * e.g. scala.collection.immutable.List or scala.collection.immutable.Seq */
-  def subSeq[B](f: A => Seq[B])(implicit ev: SeqPropertyCreator[B, Seq]): SeqProperty[B, CastableProperty[B]] =
-    macro io.udash.macros.PropertyMacros.reifySubSeq[A, B]
+  def subSeq[B, SeqTpe[B] <: Seq[B]](f: A => SeqTpe[B])(
+    implicit ev: SeqPropertyCreator[B, SeqTpe], cbf: CanBuildFrom[Nothing, B, SeqTpe[B]]
+  ): SeqProperty[B, CastableProperty[B]] = macro io.udash.macros.PropertyMacros.reifySubSeq[A, B, SeqTpe]
 }
 

--- a/core/src/main/scala/io/udash/properties/model/ReadableModelProperty.scala
+++ b/core/src/main/scala/io/udash/properties/model/ReadableModelProperty.scala
@@ -18,7 +18,7 @@ trait ReadableModelProperty[A] extends ReadableProperty[A] {
     macro io.udash.macros.PropertyMacros.reifyRoSubProp[A, B]
 
   /** Returns child DirectSeqProperty[B] */
-  def roSubSeq[B](f: A => Seq[B])(implicit ev: SeqPropertyCreator[B]): ReadableSeqProperty[B, CastableReadableProperty[B]] =
+  def roSubSeq[B](f: A => Seq[B])(implicit ev: SeqPropertyCreator[B, Seq]): ReadableSeqProperty[B, CastableReadableProperty[B]] =
     macro io.udash.macros.PropertyMacros.reifyRoSubSeq[A, B]
 
   /** Ensures read-only access to this property. */
@@ -42,6 +42,7 @@ private[properties] trait AbstractReadableModelProperty[A]
     */
   override def isValid: Future[ValidationResult] = {
     import Validator._
+
     import scala.concurrent.ExecutionContext.Implicits.global
 
     if (validationResult == null) {

--- a/core/src/main/scala/io/udash/properties/seq/DirectSeqPropertyImpl.scala
+++ b/core/src/main/scala/io/udash/properties/seq/DirectSeqPropertyImpl.scala
@@ -4,7 +4,10 @@ import io.udash.properties.single.{CastableProperty, ReadableProperty}
 import io.udash.properties.{PropertyCreator, PropertyId}
 import io.udash.utils.CrossCollections
 
-private[properties] class DirectSeqPropertyImpl[A: PropertyCreator](val parent: ReadableProperty[_], override val id: PropertyId)
+import scala.collection.generic.CanBuildFrom
+
+private[properties] class DirectSeqPropertyImpl[A: PropertyCreator, SeqTpe[T] <: Seq[T]](
+  val parent: ReadableProperty[_], override val id: PropertyId)(implicit cbf: CanBuildFrom[Nothing, A, SeqTpe[A]])
   extends AbstractSeqProperty[A, CastableProperty[A]] with CastableProperty[Seq[A]] {
 
   private val properties = CrossCollections.createArray[CastableProperty[A]]
@@ -36,6 +39,5 @@ private[properties] class DirectSeqPropertyImpl[A: PropertyCreator](val parent: 
   override def touch(): Unit =
     replace(0, properties.length, get: _*)
 
-  def get: Seq[A] =
-    properties.map(_.get)
+  def get: SeqTpe[A] = properties.map(_.get).to[SeqTpe]
 }

--- a/core/src/main/scala/io/udash/properties/seq/SeqProperty.scala
+++ b/core/src/main/scala/io/udash/properties/seq/SeqProperty.scala
@@ -5,15 +5,15 @@ import io.udash.properties.single.{AbstractProperty, CastableProperty, Property}
 
 object SeqProperty {
   /** Creates a blank DirectSeqProperty[T]. */
-  def blank[T](implicit pc: SeqPropertyCreator[T], blank: Blank[Seq[T]]): SeqProperty[T, CastableProperty[T]] =
+  def blank[T](implicit pc: SeqPropertyCreator[T, Seq], blank: Blank[Seq[T]]): SeqProperty[T, CastableProperty[T]] =
     Property.blank[Seq[T]](pc, blank).asSeq[T]
 
   /** Creates a DirectSeqProperty[T] with initial value. */
-  def apply[T: SeqPropertyCreator](item: T, more: T*): SeqProperty[T, CastableProperty[T]] =
+  def apply[T](item: T, more: T*)(implicit pc: SeqPropertyCreator[T, Seq]): SeqProperty[T, CastableProperty[T]] =
     apply(item +: more)
 
   /** Creates a DirectSeqProperty[T] with initial value. */
-  def apply[T](init: Seq[T])(implicit pc: SeqPropertyCreator[T]): SeqProperty[T, CastableProperty[T]] =
+  def apply[T](init: Seq[T])(implicit pc: SeqPropertyCreator[T, Seq]): SeqProperty[T, CastableProperty[T]] =
     Property[Seq[T]](init)(pc).asSeq[T]
 }
 

--- a/core/src/main/scala/io/udash/properties/single/CastableProperty.scala
+++ b/core/src/main/scala/io/udash/properties/single/CastableProperty.scala
@@ -13,7 +13,7 @@ trait CastableReadableProperty[A] extends ReadableProperty[A] {
     this.asInstanceOf[ReadableModelProperty[A]]
 
   /** Safely casts DirectProperty[Seq[A]] to DirectSeqProperty[A] */
-  def asSeq[B](implicit sev: A <:< Seq[B], ev: SeqPropertyCreator[B]): ReadableSeqProperty[B, CastableReadableProperty[B]] =
+  def asSeq[B](implicit sev: A <:< Seq[B], ev: SeqPropertyCreator[B, Seq]): ReadableSeqProperty[B, CastableReadableProperty[B]] =
     this.asInstanceOf[ReadableSeqProperty[B, CastableReadableProperty[B]]]
 }
 
@@ -32,7 +32,7 @@ trait CastableProperty[A] extends CastableReadableProperty[A] with Property[A] {
   }
 
   /** Safely casts `DirectProperty[Seq[A]]` to `DirectSeqProperty[A]` */
-  override def asSeq[B](implicit sev: A <:< Seq[B], ev: SeqPropertyCreator[B]): SeqProperty[B, CastableProperty[B]] = {
+  override def asSeq[B](implicit sev: A <:< Seq[B], ev: SeqPropertyCreator[B, Seq]): SeqProperty[B, CastableProperty[B]] = {
     this match {
       case sp: this.type with SeqProperty[_, _] => sp.asInstanceOf[SeqProperty[B, CastableProperty[B]]]
       case _ => throw new IllegalStateException("Property was created without provided SeqPropertyCreator in scope. " +

--- a/core/src/test/scala/io/udash/properties/ModelPropertyTest.scala
+++ b/core/src/test/scala/io/udash/properties/ModelPropertyTest.scala
@@ -476,18 +476,34 @@ class ModelPropertyTest extends UdashCoreTest {
       t.subProp(_.x).get.a should be("qwe")
     }
 
-    "handle Seq aliases" in {
+    "handle Seq subclasses and aliases" in {
       val mp = ModelProperty(AliasedSeqModel(Vector("abc"), Vector("def"), Vector(1), Vector("123")))
 
-      mp.subSeq(_.s1).get.head shouldBe "abc"
-      mp.subProp(_.s1).get.head shouldBe "abc"
+      mp.subSeq(_.s1).get shouldBe Seq("abc")
+      mp.subProp(_.s1).get shouldBe Vector("abc")
 
-      mp.subSeq(_.s2).get.head shouldBe "def"
-      mp.subProp(_.s2).get.head shouldBe "def"
+      mp.subSeq(_.s2).get shouldBe Seq("def")
+      mp.subProp(_.s2).get shouldBe Vector("def")
 
-      mp.subSeq(_.s3).get.head shouldBe 1
+      mp.subSeq(_.s3).get shouldBe Seq(1)
+      mp.subProp(_.s3).get shouldBe Vector(1)
 
-      mp.subSeq(_.s4).get.head shouldBe "123"
+      mp.subSeq(_.s4).get shouldBe Seq("123")
+      mp.subProp(_.s4).get shouldBe Vector("123")
+
+      val zipped = mp.subSeq(_.s1).zip(mp.subSeq(_.s2))(_ + _)
+      zipped.get shouldBe Seq("abcdef")
+
+      mp.subSeq(_.s2).prepend("abc")
+      mp.subSeq(_.s2).get shouldBe Seq("abc", "def")
+      mp.subProp(_.s2).get shouldBe Vector("abc", "def")
+      zipped.get shouldBe Seq("abcabc")
+
+      mp.subProp(_.s2).set(Vector("xyz"))
+
+      mp.subSeq(_.s2).get shouldBe Seq("xyz")
+      mp.subProp(_.s2).get shouldBe Vector("xyz")
+      zipped.get shouldBe Seq("abcxyz")
     }
   }
 

--- a/core/src/test/scala/io/udash/properties/ModelPropertyTest.scala
+++ b/core/src/test/scala/io/udash/properties/ModelPropertyTest.scala
@@ -475,5 +475,31 @@ class ModelPropertyTest extends UdashCoreTest {
       t.subProp(_.x).set(new Test.A("qwe"))
       t.subProp(_.x).get.a should be("qwe")
     }
+
+    "handle Seq aliases" in {
+      val mp = ModelProperty(AliasedSeqModel(Vector("abc"), Vector("def"), Vector(1), Vector("123")))
+
+      mp.subSeq(_.s1).get.head shouldBe "abc"
+      mp.subProp(_.s1).get.head shouldBe "abc"
+
+      mp.subSeq(_.s2).get.head shouldBe "def"
+      mp.subProp(_.s2).get.head shouldBe "def"
+
+      mp.subSeq(_.s3).get.head shouldBe 1
+
+      mp.subSeq(_.s4).get.head shouldBe "123"
+    }
   }
+
+  type SeqAlias[A] = Seq[A]
+  type VectorAlias[A] = Vector[A]
+  type IntSeq[A] = Seq[Int]
+  type WeirdSeq[A, B] = Seq[B]
+  case class AliasedSeqModel(
+    s1: SeqAlias[String],
+    s2: VectorAlias[String],
+    s3: IntSeq[String],
+    s4: WeirdSeq[Int, String]
+  )
+  object AliasedSeqModel extends HasModelPropertyCreator[AliasedSeqModel]
 }

--- a/core/src/test/scala/io/udash/properties/ModelPropertyTest.scala
+++ b/core/src/test/scala/io/udash/properties/ModelPropertyTest.scala
@@ -487,7 +487,7 @@ class ModelPropertyTest extends UdashCoreTest {
       mp.subProp(_.s2).get shouldBe a[Vector[_]]
       mp.subProp(_.s2).get should ===(Vector("def"))
 
-      mp.subSeq(_.s3).get should ===(Seq(1))
+      mp.subSeq[Int, Seq](_.s3).get should ===(Seq(1))
       mp.subProp(_.s3).get shouldBe a[Seq[_]]
       mp.subProp(_.s3).get should ===(Vector(1))
 

--- a/core/src/test/scala/io/udash/properties/ModelPropertyTest.scala
+++ b/core/src/test/scala/io/udash/properties/ModelPropertyTest.scala
@@ -479,31 +479,35 @@ class ModelPropertyTest extends UdashCoreTest {
     "handle Seq subclasses and aliases" in {
       val mp = ModelProperty(AliasedSeqModel(Vector("abc"), Vector("def"), Vector(1), Vector("123")))
 
-      mp.subSeq(_.s1).get shouldBe Seq("abc")
-      mp.subProp(_.s1).get shouldBe Vector("abc")
+      mp.subSeq(_.s1).get should ===(Seq("abc"))
+      mp.subProp(_.s1).get shouldBe a[Seq[_]]
+      mp.subProp(_.s1).get should ===(Vector("abc"))
 
-      mp.subSeq(_.s2).get shouldBe Seq("def")
-      mp.subProp(_.s2).get shouldBe Vector("def")
+      mp.subSeq(_.s2).get should ===(Seq("def"))
+      mp.subProp(_.s2).get shouldBe a[Vector[_]]
+      mp.subProp(_.s2).get should ===(Vector("def"))
 
-      mp.subSeq(_.s3).get shouldBe Seq(1)
-      mp.subProp(_.s3).get shouldBe Vector(1)
+      mp.subSeq(_.s3).get should ===(Seq(1))
+      mp.subProp(_.s3).get shouldBe a[Seq[_]]
+      mp.subProp(_.s3).get should ===(Vector(1))
 
-      mp.subSeq(_.s4).get shouldBe Seq("123")
-      mp.subProp(_.s4).get shouldBe Vector("123")
+      mp.subSeq(_.s4).get should ===(Seq("123"))
+      mp.subProp(_.s4).get shouldBe a[Seq[_]]
+      mp.subProp(_.s4).get should ===(Vector("123"))
 
       val zipped = mp.subSeq(_.s1).zip(mp.subSeq(_.s2))(_ + _)
-      zipped.get shouldBe Seq("abcdef")
+      zipped.get should ===(Seq("abcdef"))
 
       mp.subSeq(_.s2).prepend("abc")
-      mp.subSeq(_.s2).get shouldBe Seq("abc", "def")
-      mp.subProp(_.s2).get shouldBe Vector("abc", "def")
-      zipped.get shouldBe Seq("abcabc")
+      mp.subSeq(_.s2).get should ===(Seq("abc", "def"))
+      mp.subProp(_.s2).get should ===(Vector("abc", "def"))
+      zipped.get should ===(Seq("abcabc"))
 
       mp.subProp(_.s2).set(Vector("xyz"))
 
-      mp.subSeq(_.s2).get shouldBe Seq("xyz")
-      mp.subProp(_.s2).get shouldBe Vector("xyz")
-      zipped.get shouldBe Seq("abcxyz")
+      mp.subSeq(_.s2).get should ===(Seq("xyz"))
+      mp.subProp(_.s2).get should ===(Vector("xyz"))
+      zipped.get should ===(Seq("abcxyz"))
     }
   }
 

--- a/core/src/test/scala/io/udash/properties/PropertyUsageTest.scala
+++ b/core/src/test/scala/io/udash/properties/PropertyUsageTest.scala
@@ -2,6 +2,8 @@ package io.udash.properties
 
 import io.udash.testing.UdashCoreTest
 
+import scala.xml.Document
+
 class PropertyUsageTest extends UdashCoreTest {
   // DO NOT REMOVE THESE IMPORTS!
   import io.udash.properties.model._
@@ -124,7 +126,7 @@ class PropertyUsageTest extends UdashCoreTest {
   }
 
   object ClassModel {
-    case class T(i: Int, t: T, s: Seq[String])
+    case class T(i: Int, t: T, s: Seq[String], fixedSeq: Document)
     object T extends HasModelPropertyCreator[T]
   }
 
@@ -189,6 +191,18 @@ class PropertyUsageTest extends UdashCoreTest {
         |val t: ReadableModelProperty[ClassModel.T] = p.subModel(_.t)
         |val s: SeqProperty[String, _ <: ReadableProperty[String]] = p.subSeq(_.s)
         |""".stripMargin should compile
+    }
+
+    "not allow subSeq calls to fixed-param Seq types" in {
+      """
+        |val p: ModelProperty[ClassModel.T] = ModelProperty(null: ClassModel.T)
+        |p.subSeq(_.fixedSeq)
+        |""".stripMargin shouldNot compile
+
+      """
+        |val p: ModelProperty[ClassModel.T] = ModelProperty(null: ClassModel.T)
+        |p.roSubSeq(_.fixedSeq)
+        |""".stripMargin shouldNot compile
     }
   }
 

--- a/core/src/test/scala/io/udash/properties/SeqPropertyTest.scala
+++ b/core/src/test/scala/io/udash/properties/SeqPropertyTest.scala
@@ -2,7 +2,6 @@ package io.udash.properties
 
 import com.avsystem.commons._
 import com.github.ghik.silencer.silent
-import io.udash.properties.model.ModelProperty
 import io.udash.properties.seq.{Patch, ReadableSeqProperty, SeqProperty}
 import io.udash.properties.single.{Property, ReadableProperty}
 import io.udash.testing.UdashCoreTest
@@ -1434,14 +1433,6 @@ class SeqPropertyTest extends UdashCoreTest {
       indexed.get should be(numbers.get.zipWithIndex)
     }
 
-    "handle Seq aliases" in {
-      val mp = ModelProperty(AliasedSeqModel(Vector("abc"), Vector("def"), Vector(1), Vector("123")))
-      mp.subSeq(_.s1).get.head shouldBe "abc"
-      mp.subSeq(_.s2).get.head shouldBe "def"
-      mp.subSeq(_.s3).get.head shouldBe 1
-      mp.subSeq(_.s4).get.head shouldBe "123"
-    }
-
     "cancel listeners in a callback" in {
       val t = SeqProperty(42, 0, 99)
       val regs = mutable.ArrayBuffer.empty[Registration]
@@ -1468,18 +1459,6 @@ class SeqPropertyTest extends UdashCoreTest {
       results should contain theSameElementsInOrderAs Seq("1")
     }
   }
-
-  type SeqAlias[A] = Seq[A]
-  type VectorAlias[A] = Vector[A]
-  type IntSeq[A] = Seq[Int]
-  type WeirdSeq[A, B] = Seq[B]
-  case class AliasedSeqModel(
-    s1: SeqAlias[String],
-    s2: VectorAlias[String],
-    s3: IntSeq[String],
-    s4: WeirdSeq[Int, String]
-  )
-  object AliasedSeqModel extends HasModelPropertyCreator[AliasedSeqModel]
 
   "Seq[Property]" should {
     "combine into ReadableSeqProperty" in {

--- a/macros/src/main/scala/io/udash/macros/PropertyMacros.scala
+++ b/macros/src/main/scala/io/udash/macros/PropertyMacros.scala
@@ -219,8 +219,8 @@ class PropertyMacros(val ctx: blackbox.Context) extends AbstractMacroCommons(ctx
           case (name, returnTpe) =>
             val reifiedReturnTpe = reifySeqTpe(returnTpe)
             val reifiedCreatorTpe = getType(
-              if (tpe <:< SeqTpe) {
-                val dealiased = tpe.map(_.dealias).baseType(SeqTpe.typeSymbol)
+              if (returnTpe <:< SeqTpe) {
+                val dealiased = returnTpe.map(_.dealias).baseType(SeqTpe.typeSymbol)
                 tq"$SeqPropertyCreatorCls[${dealiased.typeArgs.head}]"
               }
               else tq"$PropertyCreatorCls[$reifiedReturnTpe]"

--- a/macros/src/main/scala/io/udash/macros/PropertyMacros.scala
+++ b/macros/src/main/scala/io/udash/macros/PropertyMacros.scala
@@ -397,9 +397,9 @@ class PropertyMacros(val ctx: blackbox.Context) extends AbstractMacroCommons(ctx
     }"""
   }
 
-  def reifySeqPropertyCreator[A: c.WeakTypeTag, B[A] <: Seq[A]](ev: c.Tree, cbf: c.Tree)(implicit tt: c.WeakTypeTag[B[A]]): c.Tree = {
+  def reifySeqPropertyCreator[A: c.WeakTypeTag, SeqTpe[A] <: Seq[A]](ev: c.Tree, cbf: c.Tree)(implicit tt: c.WeakTypeTag[SeqTpe[A]]): c.Tree = {
     val elemTpe = weakTypeOf[A]
-    val seqTpe = weakTypeOf[B[A]]
+    val seqTpe = weakTypeOf[SeqTpe[A]]
     if (isSeqPropertyTpe(seqTpe)) {
       val dealiased = seqTpe.map(_.dealias)
       q"new $SeqPropertyCreatorCls[$elemTpe, $dealiased]()($ev, $cbf)"

--- a/macros/src/main/scala/io/udash/macros/PropertyMacros.scala
+++ b/macros/src/main/scala/io/udash/macros/PropertyMacros.scala
@@ -217,16 +217,16 @@ class PropertyMacros(val ctx: blackbox.Context) extends AbstractMacroCommons(ctx
             ..${
         members.map {
           case (name, returnTpe) =>
-            val reifiedReturnTpe = reifySeqTpe(returnTpe)
+            val dealiased = returnTpe.map(_.dealias)
             val reifiedCreatorTpe = getType(
               if (returnTpe <:< SeqTpe) {
-                val dealiased = returnTpe.map(_.dealias).baseType(SeqTpe.typeSymbol)
-                tq"$SeqPropertyCreatorCls[${dealiased.typeArgs.head}]"
+                val seqTpe = dealiased.baseType(SeqTpe.typeSymbol)
+                tq"$SeqPropertyCreatorCls[${seqTpe.typeArgs.head}, ${dealiased.typeConstructor}]"
               }
-              else tq"$PropertyCreatorCls[$reifiedReturnTpe]"
+              else tq"$PropertyCreatorCls[$returnTpe]"
             )
 
-            q"""properties(${name.toString}) = implicitly[$reifiedCreatorTpe].newProperty(null.asInstanceOf[$reifiedReturnTpe], this)"""
+            q"""properties(${name.toString}) = implicitly[$reifiedCreatorTpe].newProperty(null.asInstanceOf[$dealiased], this)"""
         }
       }
           }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   val scalaCssVersion = "0.5.6"
 
   val servletVersion = "4.0.1"
-  val avsCommonsVersion = "1.34.19"
+  val avsCommonsVersion = "1.34.20-SNAPSHOT"
 
   val atmosphereJSVersion = "2.3.8"
   val atmosphereVersion = "2.5.3"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   val scalaCssVersion = "0.5.6"
 
   val servletVersion = "4.0.1"
-  val avsCommonsVersion = "1.34.20-SNAPSHOT"
+  val avsCommonsVersion = "1.34.19"
 
   val atmosphereJSVersion = "2.3.8"
   val atmosphereVersion = "2.5.3"


### PR DESCRIPTION
This PR patches the issues introduced by adding `Seq` subtypes support in models.

I've detected 2 major issues so far and fixed them here:
1. `.subProp(_.myVector).get` would lead to a runtime class cast exception
2. `Seq` subtypes with wrong shape wouldn't work (easier to work around when there are just "more" type args, worse when the type was e.g. `scala.xml.Document`, which happens to be an `AbstractSeq[Node]`)

The approach I've taken is to:
- patch `DirectSeqPropertyImpl#get` to map to correct sequence type
- ensure `SeqPropertyCreator` implicit search is used when we're working on `SeqProperties` (as opposed to previous "spray and pray" method (look for a `PropertyCreator` and cast to `SeqPropertyCreator`)
- verify what I can outside of macros with `SeqTpe[A] <:< Seq[A]` and `CanBuildFrom` requirements
- check edge cases in macros `reifySeqPropertyCreator`, `reifySubSeq`, `reifyRoSubSeq`
- cleanup and unify property macro code in regards to validating sequence types

I've tried patching returned subproperties with some delegation magic before this - it also worked, but there were multiple ugly casts/edge cases to consider that I wouldn't remember a week from now.