### PR TITLE
REST: support for comma-separated, repeated and flag `@Query` params

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -14,6 +14,7 @@
       </option>
       <option name="PLACE_SELF_TYPE_ON_NEW_LINE" value="false" />
       <option name="BLANK_LINES_AROUND_METHOD_IN_INNER_SCOPES" value="0" />
+      <option name="USE_SCALADOC2_FORMATTING" value="true" />
     </ScalaCodeStyleSettings>
     <codeStyleSettings language="Scala">
       <option name="BLANK_LINES_AROUND_CLASS" value="0" />

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,6 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
     <option name="USE_PER_PROJECT_SETTINGS" value="true" />
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
   </state>
 </component>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val scalaCssVersion = "0.5.6"
 
   val servletVersion = "4.0.1"
-  val avsCommonsVersion = "1.37.0"
+  val avsCommonsVersion = "1.38.0"
 
   val atmosphereJSVersion = "2.3.8"
   val atmosphereVersion = "2.5.3"

--- a/rest/.jvm/src/main/scala/io/udash/rest/RestServlet.scala
+++ b/rest/.jvm/src/main/scala/io/udash/rest/RestServlet.scala
@@ -74,7 +74,7 @@ class RestServlet(
     // can't use request.getPathInfo because it decodes the URL before we can split it
     val pathPrefix = request.getContextPath.orEmpty + request.getServletPath.orEmpty
     val path = PlainValue.decodePath(request.getRequestURI.stripPrefix(pathPrefix))
-    val query = request.getQueryString.opt.map(PlainValue.decodeQuery).getOrElse(Mapping.empty)
+    val query = request.getQueryString.opt.map(RawQueryValue.decodeQuery).getOrElse(Mapping.empty)
     val headersBuilder = IMapping.newBuilder[PlainValue]
     request.getHeaderNames.asScala.foreach { headerName =>
       if (!headerName.equalsIgnoreCase(CookieHeader)) { // cookies are separate, don't include them into header params

--- a/rest/.jvm/src/test/scala/io/udash/rest/EndpointsIntegrationTest.scala
+++ b/rest/.jvm/src/test/scala/io/udash/rest/EndpointsIntegrationTest.scala
@@ -48,7 +48,7 @@ class EndpointsIntegrationTest extends UdashSharedTest with BeforeAndAfterAll wi
     RestParameters(
       PlainValue.decodePath(url),
       IMapping(headers.mapValues(PlainValue).toList),
-      Mapping(queryArguments.mapValues(PlainValue).toList)
+      Mapping(queryArguments.mapValues(RawQueryValue.plain(_)).toList)
     ),
     HttpBody.json(JsonValue(body))
   )

--- a/rest/jetty/src/main/scala/io/udash/rest/jetty/JettyRestClient.scala
+++ b/rest/jetty/src/main/scala/io/udash/rest/jetty/JettyRestClient.scala
@@ -12,8 +12,8 @@ import org.eclipse.jetty.client.api.Result
 import org.eclipse.jetty.client.util.{BufferingResponseListener, BytesContentProvider, StringContentProvider}
 import org.eclipse.jetty.http.{HttpHeader, MimeTypes}
 
-import scala.util.{Failure, Success}
 import scala.concurrent.duration._
+import scala.util.{Failure, Success}
 
 object JettyRestClient {
   final val DefaultMaxResponseLength = 2 * 1024 * 1024
@@ -35,13 +35,14 @@ object JettyRestClient {
   ): RawRest.HandleRequest =
     RawRest.safeHandle { request =>
       callback =>
-        val path = baseUrl + PlainValue.encodePath(request.parameters.path)
-        val httpReq = client.newRequest(baseUrl).method(request.method.name)
-
-        httpReq.path(path)
-        request.parameters.query.entries.foreach {
-          case (name, PlainValue(value)) => httpReq.param(name, value)
+        val urlBuilder = new StringBuilder
+        urlBuilder.append(PlainValue.encodePath(request.parameters.path))
+        if (request.parameters.query.nonEmpty) {
+          urlBuilder.append("?")
         }
+        urlBuilder.append(RawQueryValue.encodeQuery(request.parameters.query))
+        val httpReq = client.newRequest(urlBuilder.result()).method(request.method.name)
+
         request.parameters.headers.entries.foreach {
           case (name, PlainValue(value)) => httpReq.header(name, value)
         }

--- a/rest/jetty/src/main/scala/io/udash/rest/jetty/JettyRestClient.scala
+++ b/rest/jetty/src/main/scala/io/udash/rest/jetty/JettyRestClient.scala
@@ -35,13 +35,8 @@ object JettyRestClient {
   ): RawRest.HandleRequest =
     RawRest.safeHandle { request =>
       callback =>
-        val urlBuilder = new StringBuilder
-        urlBuilder.append(PlainValue.encodePath(request.parameters.path))
-        if (request.parameters.query.nonEmpty) {
-          urlBuilder.append("?")
-        }
-        urlBuilder.append(RawQueryValue.encodeQuery(request.parameters.query))
-        val httpReq = client.newRequest(urlBuilder.result()).method(request.method.name)
+        val url = request.parameters.toUri(baseUrl)
+        val httpReq = client.newRequest(url).method(request.method.name)
 
         request.parameters.headers.entries.foreach {
           case (name, PlainValue(value)) => httpReq.header(name, value)

--- a/rest/src/main/scala/io/udash/rest/RestDataCompanion.scala
+++ b/rest/src/main/scala/io/udash/rest/RestDataCompanion.scala
@@ -7,7 +7,7 @@ import com.avsystem.commons.rpc.{AsRaw, AsReal}
 import com.avsystem.commons.serialization.{GenCodec, TransparentWrapperCompanion}
 import io.udash.rest.openapi.RestStructure.NameAndAdjusters
 import io.udash.rest.openapi._
-import io.udash.rest.raw.{HttpBody, JsonValue, PlainValue, RestResponse}
+import io.udash.rest.raw._
 
 trait CodecWithStructure[T] {
   def codec: GenCodec[T]
@@ -61,6 +61,12 @@ abstract class RestDataWrapperCompanion[Wrapped, T](implicit
     AsRaw.fromTransparentWrapping
 
   implicit def plainAsReal(implicit wrappedAsRaw: AsReal[PlainValue, Wrapped]): AsReal[PlainValue, T] =
+    AsReal.fromTransparentWrapping
+
+  implicit def rawQueryAsRaw(implicit wrappedAsRaw: AsRaw[RawQueryValue, Wrapped]): AsRaw[RawQueryValue, T] =
+    AsRaw.fromTransparentWrapping
+
+  implicit def rawQueryAsReal(implicit wrappedAsRaw: AsReal[RawQueryValue, Wrapped]): AsReal[RawQueryValue, T] =
     AsReal.fromTransparentWrapping
 
   implicit def jsonAsRaw(implicit wrappedAsRaw: AsRaw[JsonValue, Wrapped]): AsRaw[JsonValue, T] =

--- a/rest/src/main/scala/io/udash/rest/SttpRestClient.scala
+++ b/rest/src/main/scala/io/udash/rest/SttpRestClient.scala
@@ -3,8 +3,6 @@ package rest
 
 import com.avsystem.commons._
 import com.avsystem.commons.annotation.explicitGenerics
-import com.softwaremill.sttp.Uri.QueryFragment.Plain
-import com.softwaremill.sttp.Uri.QueryFragmentEncoding
 import com.softwaremill.sttp._
 import io.udash.rest.raw._
 
@@ -30,14 +28,9 @@ object SttpRestClient {
     asHandleRequest(uri"$baseUri")
 
   private def toSttpRequest(baseUri: Uri, request: RestRequest): Request[Array[Byte], Nothing] = {
-    val uri = baseUri |>
-      (u => u.copy(path = u.path ++
-        request.parameters.path.map(_.value))) |>
-      (u => u.copy(queryFragments = u.queryFragments ++
-        request.parameters.query.entries.iterator.map {
-          case (k, rqv) => Plain(rqv.encodeParam(k), QueryFragmentEncoding.Relaxed)
-        }.toList
-      ))
+    val tmpUri = uri"${request.parameters.toUri(s"tmp://tmp")}"
+    val uri = baseUri |> (u =>
+      u.copy(path = u.path ++ tmpUri.path, queryFragments = u.queryFragments ++ tmpUri.queryFragments))
 
     val contentHeaders = request.body match {
       case HttpBody.Empty => Nil

--- a/rest/src/main/scala/io/udash/rest/SttpRestClient.scala
+++ b/rest/src/main/scala/io/udash/rest/SttpRestClient.scala
@@ -3,7 +3,7 @@ package rest
 
 import com.avsystem.commons._
 import com.avsystem.commons.annotation.explicitGenerics
-import com.softwaremill.sttp.Uri.QueryFragment.KeyValue
+import com.softwaremill.sttp.Uri.QueryFragment.Plain
 import com.softwaremill.sttp.Uri.QueryFragmentEncoding
 import com.softwaremill.sttp._
 import io.udash.rest.raw._
@@ -35,7 +35,7 @@ object SttpRestClient {
         request.parameters.path.map(_.value))) |>
       (u => u.copy(queryFragments = u.queryFragments ++
         request.parameters.query.entries.iterator.map {
-          case (k, PlainValue(v)) => KeyValue(k, v, QueryFragmentEncoding.All, QueryFragmentEncoding.All)
+          case (k, rqv) => Plain(rqv.encodeParam(k), QueryFragmentEncoding.Relaxed)
         }.toList
       ))
 

--- a/rest/src/main/scala/io/udash/rest/raw/HttpBody.scala
+++ b/rest/src/main/scala/io/udash/rest/raw/HttpBody.scala
@@ -145,12 +145,12 @@ object HttpBody extends HttpBodyLowPrio {
 
   def json(json: JsonValue): HttpBody = textual(json.value, JsonType)
 
-  def createFormBody(values: Mapping[PlainValue]): HttpBody =
-    if (values.isEmpty) HttpBody.Empty else textual(PlainValue.encodeQuery(values), FormType)
+  def createFormBody(values: Mapping[RawQueryValue]): HttpBody =
+    if (values.isEmpty) HttpBody.Empty else textual(RawQueryValue.encodeQuery(values), FormType)
 
-  def parseFormBody(body: HttpBody): Mapping[PlainValue] = body match {
-    case HttpBody.Empty => Mapping.empty[PlainValue]
-    case _ => PlainValue.decodeQuery(body.readForm())
+  def parseFormBody(body: HttpBody): Mapping[RawQueryValue] = body match {
+    case HttpBody.Empty => Mapping.empty[RawQueryValue]
+    case _ => RawQueryValue.decodeQuery(body.readForm())
   }
 
   def createJsonBody(fields: Mapping[JsonValue]): HttpBody =

--- a/rest/src/main/scala/io/udash/rest/raw/PlainValue.scala
+++ b/rest/src/main/scala/io/udash/rest/raw/PlainValue.scala
@@ -19,5 +19,10 @@ object PlainValue extends (String => PlainValue) {
     }
 
   def encodePath(path: List[PlainValue]): String =
-    path.iterator.map(pv => URLEncoder.encode(pv.value, spaceAsPlus = false)).mkString("/", "/", "")
+    encodePath(path, new StringBuilder).result()
+
+  def encodePath(path: List[PlainValue], sb: StringBuilder): StringBuilder = {
+    path.foreach(pv => sb.append("/").append(URLEncoder.encode(pv.value, spaceAsPlus = false)))
+    sb
+  }
 }

--- a/rest/src/main/scala/io/udash/rest/raw/PlainValue.scala
+++ b/rest/src/main/scala/io/udash/rest/raw/PlainValue.scala
@@ -20,22 +20,4 @@ object PlainValue extends (String => PlainValue) {
 
   def encodePath(path: List[PlainValue]): String =
     path.iterator.map(pv => URLEncoder.encode(pv.value, spaceAsPlus = false)).mkString("/", "/", "")
-
-  final val FormKVSep = "="
-  final val FormKVPairSep = "&"
-
-  def encodeQuery(query: Mapping[PlainValue]): String =
-    query.entries.iterator.map { case (name, PlainValue(value)) =>
-      s"${URLEncoder.encode(name, spaceAsPlus = true)}$FormKVSep${URLEncoder.encode(value, spaceAsPlus = true)}"
-    }.mkString(FormKVPairSep)
-
-  def decodeQuery(queryString: String): Mapping[PlainValue] = {
-    val builder = Mapping.newBuilder[PlainValue]
-    queryString.split(FormKVPairSep).iterator.filter(_.nonEmpty).map(_.split(FormKVSep, 2)).foreach {
-      case Array(name, value) => builder +=
-        URLEncoder.decode(name, plusAsSpace = true) -> PlainValue(URLEncoder.decode(value, plusAsSpace = true))
-      case _ => throw new IllegalArgumentException(s"invalid query string $queryString")
-    }
-    builder.result()
-  }
 }

--- a/rest/src/main/scala/io/udash/rest/raw/RawQueryValue.scala
+++ b/rest/src/main/scala/io/udash/rest/raw/RawQueryValue.scala
@@ -1,0 +1,171 @@
+package io.udash
+package rest.raw
+
+import com.avsystem.commons._
+import com.avsystem.commons.misc.ImplicitNotFound
+import com.avsystem.commons.rpc.{AsRaw, AsReal}
+import io.udash.utils.URLEncoder
+
+import scala.annotation.{implicitNotFound, tailrec}
+import scala.collection.AbstractIterator
+import scala.collection.generic.CanBuildFrom
+
+/**
+  * The raw data type which all query parameter values are serialized into, i.e. the RPC macro engine looks
+  * for `AsRaw/AsReal[RawQueryValue, T]` for every [[io.udash.rest.Query Query]] parameter of type `T`.
+  *
+  * Represents an URI query parameter (or sequence of adjacent parameters with the same name),
+  * in a raw form which makes it possible to support repeated, flag and binary parameters.
+  * Unlike [[PlainValue]], raw strings inside `RawQueryValue` must be already URL-encoded.
+  *
+  * Examples:
+  * `&flag` -> `Single(Opt.Empty)`
+  * `&key=value` -> `Single(Opt("value"))`
+  * `&key=value1&key=value2` -> `Multiple(Opt("value1"), Single(Opt("value2"))`
+  * `&key=va%7Clue` -> `Single(Opt("va%7Clue")`
+  */
+sealed abstract class RawQueryValue {
+
+  import RawQueryValue._
+
+  def first: Opt[String] = this match {
+    case Single(encoded) => encoded
+    case Repeated(encoded, _) => encoded
+  }
+
+  def iterator: Iterator[Opt[String]] = new AbstractIterator[Opt[String]] {
+    private var _next: RawQueryValue = RawQueryValue.this
+    def hasNext: Boolean = _next != null
+    def next(): Opt[String] = _next match {
+      case null => throw new NoSuchElementException
+      case Single(v) =>
+        _next = null
+        v
+      case Repeated(v, tail) =>
+        _next = tail
+        v
+    }
+  }
+
+  def toList: List[Opt[String]] = iterator.toList
+
+  def encodeParam(name: String): String = {
+    val encName = urlEncode(name)
+    val sb = new StringBuilder
+
+    def append(enc: Opt[String]): Unit = enc match {
+      case Opt.Empty => sb.append(encName)
+      case Opt(v) => sb.append(encName).append("=").append(v)
+    }
+    @tailrec def loop(rqv: RawQueryValue): Unit = rqv match {
+      case Single(v) => append(v)
+      case Repeated(h, t) =>
+        append(h)
+        sb.append("&")
+        loop(t)
+    }
+    loop(this)
+    sb.result()
+  }
+
+  def exploded: RawQueryValue = RawQueryValue.fromRaw {
+    val it = iterator.flatMap {
+      case Opt.Empty | Opt("") => Iterator.empty
+      case Opt(v) => v.split(",").iterator.map(Opt(_))
+    }
+    if (it.nonEmpty) it else Iterator(Opt.Empty)
+  }
+
+  def unexploded: RawQueryValue =
+    Single(Opt(iterator.flatten.mkString(",")))
+
+  def firstPlainValue: PlainValue =
+    PlainValue(first.fold("")(urlDecode))
+}
+object RawQueryValue {
+  def fromRaw(values: TraversableOnce[Opt[String]]): RawQueryValue =
+    if (values.isEmpty) throw new IllegalArgumentException("no values")
+    else values.foldRight(null: RawQueryValue) {
+      case (v, null) => Single(v)
+      case (v, tail) => Repeated(v, tail)
+    }
+
+  def plain(value: String): RawQueryValue =
+    Single(Opt(urlEncode(value)))
+
+  /**
+    * @param encoded If non-empty, contains an already URL-encoded string (it may contain unencoded commas to indicate
+    *                a list of values). `Opt.Empty` indicates a "flag" query parameter (without `=` and value).
+    */
+  // not using plain List in order to statically ensure non-emptiness and avoid too much boxing of Opts
+  case class Single(encoded: Opt[String]) extends RawQueryValue
+  case class Repeated(encoded: Opt[String], tail: RawQueryValue) extends RawQueryValue
+
+  def urlEncode(str: String): String =
+    URLEncoder.encode(str, spaceAsPlus = true)
+
+  def urlDecode(str: String): String =
+    URLEncoder.decode(str, plusAsSpace = true)
+
+  def encodeQuery(query: Mapping[RawQueryValue]): String =
+    query.entries.iterator.map { case (name, rqv) => rqv.encodeParam(name) }.mkString("&")
+
+  def decodeQuery(queryString: String): Mapping[RawQueryValue] = {
+    def splitPart(part: String): (String, String) = part.split("=", 2) match {
+      case Array(name, value) => urlDecode(name) -> value
+      case Array(name) => urlDecode(name) -> null
+    }
+    val entries = queryString.split("&").foldRight(List.empty[(String, RawQueryValue)]) {
+      case (part, Nil) => splitPart(part) match {
+        case (n, v) => List(n -> Single(v.opt))
+      }
+      case (part, (nextName, nextRqv) :: tail) => splitPart(part) match {
+        // only grouping adjacent params with the same name into Multiple TODO improve?
+        case (`nextName`, v) => (nextName, Repeated(v.opt, nextRqv)) :: tail
+        case (name, v) => (name, Single(v.opt)) :: (nextName, nextRqv) :: tail
+      }
+    }
+    Mapping(entries)
+  }
+
+  implicit def plainValueBasedAsRaw[T](implicit asPlain: AsRaw[PlainValue, T]): AsRaw[RawQueryValue, T] =
+    AsRaw.create(real => Single(urlEncode(asPlain.asRaw(real).value).opt))
+
+  implicit def plainValueBasedAsReal[T](implicit fromPlain: AsReal[PlainValue, T]): AsReal[RawQueryValue, T] =
+    AsReal.create(raw => fromPlain.asReal(raw.firstPlainValue))
+
+  // comma-separated representation of collections (OpenAPI Parameter: explode = false)
+  // FIXME: a collection containing single empty string is unrepresentable (even with explode = true)
+  implicit def plainValueBasedIterableAsRaw[C[X] <: BIterable[X], T](
+    implicit asPlain: AsRaw[PlainValue, T]
+  ): AsRaw[RawQueryValue, C[T]] =
+    AsRaw.create(real => Single(real.iterator.map(v => urlEncode(asPlain.asRaw(v).value)).mkString(",").opt))
+
+  implicit def plainValueBasedIterableAsReal[C[X] <: BIterable[X], T](
+    implicit fromPlain: AsReal[PlainValue, T], cbf: CanBuildFrom[Nothing, T, C[T]]
+  ): AsReal[RawQueryValue, C[T]] =
+    AsReal.create(_.iterator.flatMap { vopt =>
+      vopt.filter(_.nonEmpty).map(_.split(",").iterator).getOrElse(Iterator.empty)
+        .map(v => fromPlain.asReal(PlainValue(urlDecode(v))))
+    }.to[C])
+
+  @implicitNotFound("#{forPlain}")
+  implicit def asRealNotFound[T](
+    implicit forPlain: ImplicitNotFound[AsReal[PlainValue, T]]
+  ): ImplicitNotFound[AsReal[RawQueryValue, T]] = ImplicitNotFound()
+
+  @implicitNotFound("#{forPlain}")
+  implicit def asRawNotFound[T](
+    implicit forJson: ImplicitNotFound[AsRaw[PlainValue, T]]
+  ): ImplicitNotFound[AsRaw[RawQueryValue, T]] = ImplicitNotFound()
+
+  @implicitNotFound("#{forPlain}")
+  implicit def iterableAsRealNotFound[C[X] <: BIterable[X], T](
+    implicit forPlain: ImplicitNotFound[AsReal[PlainValue, T]]
+  ): ImplicitNotFound[AsReal[RawQueryValue, C[T]]] = ImplicitNotFound()
+
+  @implicitNotFound("#{forPlain}")
+  implicit def iterableAsRawNotFound[C[X] <: BIterable[X], T](
+    implicit forJson: ImplicitNotFound[AsRaw[PlainValue, T]]
+  ): ImplicitNotFound[AsRaw[RawQueryValue, C[T]]] = ImplicitNotFound()
+}

--- a/rest/src/main/scala/io/udash/rest/raw/RestRequest.scala
+++ b/rest/src/main/scala/io/udash/rest/raw/RestRequest.scala
@@ -23,7 +23,7 @@ object HttpMethod extends AbstractValueEnumCompanion[HttpMethod] {
 final case class RestParameters(
   @multi @tagged[Path] path: List[PlainValue] = Nil,
   @multi @tagged[Header] headers: IMapping[PlainValue] = IMapping.empty,
-  @multi @tagged[Query] query: Mapping[PlainValue] = Mapping.empty,
+  @multi @tagged[Query] query: Mapping[RawQueryValue] = Mapping.empty,
   @multi @tagged[Cookie] cookies: Mapping[PlainValue] = Mapping.empty
 ) {
   def append(method: RestMethodMetadata[_], otherParameters: RestParameters): RestParameters =
@@ -41,10 +41,10 @@ final case class RestParameters(
     copy(headers = headers.append(name, PlainValue(value)))
 
   def query(name: String, value: String): RestParameters =
-    copy(query = query.append(name, PlainValue(value)))
+    copy(query = query.append(name, RawQueryValue.plain(value)))
 
   def cookie(name: String, value: String): RestParameters =
-    copy(query = cookies.append(name, PlainValue(value)))
+    copy(cookies = cookies.append(name, PlainValue(value)))
 }
 object RestParameters {
   final val Empty = RestParameters()

--- a/rest/src/main/scala/io/udash/rest/raw/RestRequest.scala
+++ b/rest/src/main/scala/io/udash/rest/raw/RestRequest.scala
@@ -26,6 +26,20 @@ final case class RestParameters(
   @multi @tagged[Query] query: Mapping[RawQueryValue] = Mapping.empty,
   @multi @tagged[Cookie] cookies: Mapping[PlainValue] = Mapping.empty
 ) {
+
+  /**
+    * Appends path and query parameters to given base URI. Base URI must not contain query parameters.
+    */
+  def toUri(baseUri: String): String = {
+    val builder = new StringBuilder(baseUri.stripSuffix("/"))
+    PlainValue.encodePath(path, builder)
+    if (query.nonEmpty) {
+      builder.append("?")
+    }
+    RawQueryValue.encodeQuery(query, builder)
+    builder.result()
+  }
+
   def append(method: RestMethodMetadata[_], otherParameters: RestParameters): RestParameters =
     RestParameters(
       path ::: method.applyPathParams(otherParameters.path),


### PR DESCRIPTION
Primary motivation: to allow `List`s and other collections to be used as types of `@Query` parameters

Details:
* `@Query` parameters now serialize to new raw type, `RawQueryValue` instead of `PlainValue`
* `RawQueryValue` allows emitting query strings previously impossible to express:
  * comma separated lists of URL-encoded values, e.g. `ids=1,2,3` (separating commas are *not* URL-encoded but commas appearing in values *are*)
  * repeated parameters, e.g. `id=1&id=2&id=3` (assuming they're not interspersed with other params)
  * parameters without the `=`, e.g. `?enabled` instead of `?enabled=true`
  * binary URL-encoded values which are not valid UTF-8 strings after decoding
* by default, `RawQueryValue` serialization reuses `PlainValue` serialization
* `RawQueryValue` serialization is also provided for any `Iterable` (or subclass) of element `T` given that `PlainValue` serialization is available for `T` - this serialization uses comma-separated representation
* `@explode` annotation may be used to change comma-separated representation into repeated parameters
* `@flag` annotation may be used on `Boolean` query params to use `?param` instead of `?param=true`

The changes above required two new features in RPC framework:
* `EncodingInterceptor` and `DecodingInterceptor` for defining annotations which change serialization of annotated parameter/method
* `@rawWhenAbsent` annotation for providing raw (serialized) default parameter values