### PR TITLE
Allow unboxed series data

### DIFF
--- a/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/area/SeriesArea.scala
+++ b/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/area/SeriesArea.scala
@@ -123,7 +123,7 @@ object SeriesArea {
             cropThreshold: js.UndefOr[Double] = js.undefined,
             cursor: js.UndefOr[String] = js.undefined,
             dashStyle: js.UndefOr[DashStyle] = js.undefined,
-            data: Seq[SeriesAreaData | Double] = Seq.empty,
+            data: Seq[Double | SeriesAreaData | js.Array[Double]] = Seq.empty,
             dataLabels: js.UndefOr[SeriesDataLabels] = js.undefined,
             description: js.UndefOr[String] = js.undefined,
             enableMouseTracking: js.UndefOr[Boolean] = js.undefined,

--- a/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/arearange/SeriesArearange.scala
+++ b/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/arearange/SeriesArearange.scala
@@ -84,7 +84,7 @@ object SeriesArearange {
             cropThreshold: js.UndefOr[Double] = js.undefined,
             cursor: js.UndefOr[String] = js.undefined,
             dashStyle: js.UndefOr[DashStyle] = js.undefined,
-            data: Seq[SeriesArearangeData] = Seq.empty,
+            data: Seq[js.Array[Double] | SeriesArearangeData] = Seq.empty,
             dataLabels: js.UndefOr[SeriesRangeDataLabels] = js.undefined,
             description: js.UndefOr[String] = js.undefined,
             enableMouseTracking: js.UndefOr[Boolean] = js.undefined,

--- a/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/areaspline/SeriesAreaspline.scala
+++ b/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/areaspline/SeriesAreaspline.scala
@@ -112,7 +112,7 @@ object SeriesAreaspline {
             cropThreshold: js.UndefOr[Double] = js.undefined,
             cursor: js.UndefOr[String] = js.undefined,
             dashStyle: js.UndefOr[DashStyle] = js.undefined,
-            data: Seq[SeriesAreasplineData | Double] = Seq.empty,
+            data: Seq[Double | SeriesAreasplineData | js.Array[Double]] = Seq.empty,
             dataLabels: js.UndefOr[SeriesDataLabels] = js.undefined,
             description: js.UndefOr[String] = js.undefined,
             enableMouseTracking: js.UndefOr[Boolean] = js.undefined,

--- a/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/areasplinerange/SeriesAreasplinerange.scala
+++ b/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/areasplinerange/SeriesAreasplinerange.scala
@@ -76,7 +76,7 @@ object SeriesAreasplinerange {
             cropThreshold: js.UndefOr[Double] = js.undefined,
             cursor: js.UndefOr[String] = js.undefined,
             dashStyle: js.UndefOr[DashStyle] = js.undefined,
-            data: Seq[SeriesAreasplinerangeData] = Seq.empty,
+            data: Seq[js.Array[Double] | SeriesAreasplinerangeData] = Seq.empty,
             dataLabels: js.UndefOr[SeriesRangeDataLabels] = js.undefined,
             description: js.UndefOr[String] = js.undefined,
             enableMouseTracking: js.UndefOr[Boolean] = js.undefined,

--- a/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/bar/SeriesBar.scala
+++ b/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/bar/SeriesBar.scala
@@ -90,7 +90,7 @@ object SeriesBar {
             crisp: js.UndefOr[Boolean] = js.undefined,
             cropThreshold: js.UndefOr[Double] = js.undefined,
             cursor: js.UndefOr[String] = js.undefined,
-            data: Seq[SeriesBarData | Double] = Seq.empty,
+            data: Seq[Double | js.Array[Double] | SeriesBarData] = Seq.empty,
             dataLabels: js.UndefOr[SeriesDataLabels] = js.undefined,
             description: js.UndefOr[String] = js.undefined,
             depth: js.UndefOr[Double] = js.undefined,

--- a/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/boxplot/SeriesBoxplot.scala
+++ b/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/boxplot/SeriesBoxplot.scala
@@ -113,7 +113,7 @@ object SeriesBoxplot {
             colors: js.UndefOr[Seq[Color]] = js.undefined,
             crisp: js.UndefOr[Boolean] = js.undefined,
             cursor: js.UndefOr[String] = js.undefined,
-            data: Seq[SeriesBoxplotData] = Seq.empty,
+            data: Seq[js.Array[Double] | SeriesBoxplotData] = Seq.empty,
             dataLabels: js.UndefOr[SeriesDataLabels] = js.undefined,
             description: js.UndefOr[String] = js.undefined,
             depth: js.UndefOr[Double] = js.undefined,

--- a/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/bubble/SeriesBubble.scala
+++ b/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/bubble/SeriesBubble.scala
@@ -154,7 +154,7 @@ object SeriesBubble {
             cropThreshold: js.UndefOr[Double] = js.undefined,
             cursor: js.UndefOr[String] = js.undefined,
             dashStyle: js.UndefOr[DashStyle] = js.undefined,
-            data: Seq[SeriesBubbleData | Double] = Seq.empty,
+            data: Seq[js.Array[Double] | SeriesBubbleData] = Seq.empty,
             dataLabels: js.UndefOr[SeriesDataLabels] = js.undefined,
             description: js.UndefOr[String] = js.undefined,
             displayNegative: js.UndefOr[Boolean] = js.undefined,

--- a/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/column/SeriesColumn.scala
+++ b/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/column/SeriesColumn.scala
@@ -90,7 +90,7 @@ object SeriesColumn {
             crisp: js.UndefOr[Boolean] = js.undefined,
             cropThreshold: js.UndefOr[Double] = js.undefined,
             cursor: js.UndefOr[String] = js.undefined,
-            data: Seq[SeriesColumnData | Double] = Seq.empty,
+            data: Seq[Double | js.Array[Double] | SeriesColumnData] = Seq.empty,
             dataLabels: js.UndefOr[SeriesDataLabels] = js.undefined,
             description: js.UndefOr[String] = js.undefined,
             depth: js.UndefOr[Double] = js.undefined,

--- a/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/columnrnge/SeriesColumnrange.scala
+++ b/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/columnrnge/SeriesColumnrange.scala
@@ -99,7 +99,7 @@ object SeriesColumnrange {
             crisp: js.UndefOr[Boolean] = js.undefined,
             cropThreshold: js.UndefOr[Double] = js.undefined,
             cursor: js.UndefOr[String] = js.undefined,
-            data: Seq[SeriesColumnrangeData] = Seq.empty,
+            data: Seq[js.Array[Double] | SeriesColumnrangeData] = Seq.empty,
             dataLabels: js.UndefOr[SeriesRangeDataLabels] = js.undefined,
             description: js.UndefOr[String] = js.undefined,
             depth: js.UndefOr[Double] = js.undefined,

--- a/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/errorbar/SeriesErrorbar.scala
+++ b/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/errorbar/SeriesErrorbar.scala
@@ -78,7 +78,7 @@ object SeriesErrorbar {
             colors: js.UndefOr[Seq[Color]] = js.undefined,
             crisp: js.UndefOr[Boolean] = js.undefined,
             cursor: js.UndefOr[String] = js.undefined,
-            data: Seq[SeriesErrorbarData] = Seq.empty,
+            data: Seq[js.Array[Double] | SeriesErrorbarData] = Seq.empty,
             dataLabels: js.UndefOr[SeriesDataLabels] = js.undefined,
             description: js.UndefOr[String] = js.undefined,
             depth: js.UndefOr[Double] = js.undefined,

--- a/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/funnel/SeriesFunnel.scala
+++ b/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/funnel/SeriesFunnel.scala
@@ -95,7 +95,7 @@ object SeriesFunnel {
             color: js.UndefOr[Color] = js.undefined,
             colors: js.UndefOr[Seq[Color]] = js.undefined,
             cursor: js.UndefOr[String] = js.undefined,
-            data: Seq[SeriesFunnelData | Double] = Seq.empty,
+            data: Seq[Double | SeriesFunnelData] = Seq.empty,
             dataLabels: js.UndefOr[SeriesConnectorDataLabels] = js.undefined,
             description: js.UndefOr[String] = js.undefined,
             depth: js.UndefOr[Double] = js.undefined,

--- a/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/guage/SeriesGauge.scala
+++ b/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/guage/SeriesGauge.scala
@@ -71,7 +71,7 @@ object SeriesGauge {
             className: js.UndefOr[String] = js.undefined,
             color: js.UndefOr[Color] = js.undefined,
             cursor: js.UndefOr[String] = js.undefined,
-            data: Seq[SeriesGaugeData | Double] = Seq.empty,
+            data: Seq[Double | SeriesGaugeData] = Seq.empty,
             dataLabels: js.UndefOr[SeriesDataLabels] = js.undefined,
             description: js.UndefOr[String] = js.undefined,
             dial: js.UndefOr[SeriesGaugeDial] = js.undefined,

--- a/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/guage/SeriesSolidgauge.scala
+++ b/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/guage/SeriesSolidgauge.scala
@@ -63,7 +63,7 @@ object SeriesSolidgauge {
             className: js.UndefOr[String] = js.undefined,
             color: js.UndefOr[Color] = js.undefined,
             cursor: js.UndefOr[String] = js.undefined,
-            data: Seq[SeriesSolidgaugeData | Double] = Seq.empty,
+            data: Seq[Double | SeriesSolidgaugeData] = Seq.empty,
             dataLabels: js.UndefOr[SeriesDataLabels] = js.undefined,
             description: js.UndefOr[String] = js.undefined,
             enableMouseTracking: js.UndefOr[Boolean] = js.undefined,

--- a/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/heatmap/SeriesHeatmap.scala
+++ b/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/heatmap/SeriesHeatmap.scala
@@ -95,7 +95,7 @@ object SeriesHeatmap {
             colsize: js.UndefOr[Double] = js.undefined,
             cropThreshold: js.UndefOr[Double] = js.undefined,
             cursor: js.UndefOr[String] = js.undefined,
-            data: Seq[SeriesHeatmapData] = Seq.empty,
+            data: Seq[js.Array[Double] | SeriesHeatmapData] = Seq.empty,
             dataLabels: js.UndefOr[SeriesDataLabels] = js.undefined,
             description: js.UndefOr[String] = js.undefined,
             enableMouseTracking: js.UndefOr[Boolean] = js.undefined,

--- a/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/line/SeriesLine.scala
+++ b/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/line/SeriesLine.scala
@@ -83,7 +83,7 @@ object SeriesLine {
             cropThreshold: js.UndefOr[Double] = js.undefined,
             cursor: js.UndefOr[String] = js.undefined,
             dashStyle: js.UndefOr[DashStyle] = js.undefined,
-            data: Seq[SeriesLineData | Double] = Seq.empty,
+            data: Seq[Double | js.Array[Double] | SeriesLineData] = Seq.empty,
             dataLabels: js.UndefOr[SeriesDataLabels] = js.undefined,
             description: js.UndefOr[String] = js.undefined,
             enableMouseTracking: js.UndefOr[Boolean] = js.undefined,

--- a/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/pie/SeriesPie.scala
+++ b/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/pie/SeriesPie.scala
@@ -107,7 +107,7 @@ object SeriesPie {
             color: js.UndefOr[Color] = js.undefined,
             colors: js.UndefOr[Seq[Color]] = js.undefined,
             cursor: js.UndefOr[String] = js.undefined,
-            data: Seq[SeriesPieData | Double] = Seq.empty,
+            data: Seq[Double | SeriesPieData] = Seq.empty,
             dataLabels: js.UndefOr[SeriesConnectorDataLabels] = js.undefined,
             description: js.UndefOr[String] = js.undefined,
             depth: js.UndefOr[Double] = js.undefined,

--- a/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/polygon/SeriesPolygon.scala
+++ b/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/polygon/SeriesPolygon.scala
@@ -65,7 +65,7 @@ object SeriesPolygon {
             cropThreshold: js.UndefOr[Double] = js.undefined,
             cursor: js.UndefOr[String] = js.undefined,
             dashStyle: js.UndefOr[DashStyle] = js.undefined,
-            data: Seq[SeriesPolygonData | Double] = Seq.empty,
+            data: Seq[Double | js.Array[Double] | SeriesPolygonData] = Seq.empty,
             dataLabels: js.UndefOr[SeriesDataLabels] = js.undefined,
             description: js.UndefOr[String] = js.undefined,
             enableMouseTracking: js.UndefOr[Boolean] = js.undefined,

--- a/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/pyramid/SeriesPyramid.scala
+++ b/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/pyramid/SeriesPyramid.scala
@@ -81,7 +81,7 @@ object SeriesPyramid {
             color: js.UndefOr[Color] = js.undefined,
             colors: js.UndefOr[Seq[Color]] = js.undefined,
             cursor: js.UndefOr[String] = js.undefined,
-            data: Seq[SeriesPyramidData | Double] = Seq.empty,
+            data: Seq[Double | SeriesPyramidData] = Seq.empty,
             dataLabels: js.UndefOr[SeriesConnectorDataLabels] = js.undefined,
             description: js.UndefOr[String] = js.undefined,
             depth: js.UndefOr[Double] = js.undefined,

--- a/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/scatter/SeriesScatter.scala
+++ b/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/scatter/SeriesScatter.scala
@@ -79,7 +79,7 @@ object SeriesScatter {
             cropThreshold: js.UndefOr[Double] = js.undefined,
             cursor: js.UndefOr[String] = js.undefined,
             dashStyle: js.UndefOr[DashStyle] = js.undefined,
-            data: Seq[SeriesScatterData | Double] = Seq.empty,
+            data: Seq[Double | js.Array[Double] | SeriesScatterData] = Seq.empty,
             dataLabels: js.UndefOr[SeriesDataLabels] = js.undefined,
             description: js.UndefOr[String] = js.undefined,
             enableMouseTracking: js.UndefOr[Boolean] = js.undefined,

--- a/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/spline/SeriesSpline.scala
+++ b/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/spline/SeriesSpline.scala
@@ -75,7 +75,7 @@ object SeriesSpline {
             cropThreshold: js.UndefOr[Double] = js.undefined,
             cursor: js.UndefOr[String] = js.undefined,
             dashStyle: js.UndefOr[DashStyle] = js.undefined,
-            data: Seq[SeriesSplineData | Double] = Seq.empty,
+            data: Seq[Double | js.Array[Double] | SeriesSplineData] = Seq.empty,
             dataLabels: js.UndefOr[SeriesDataLabels] = js.undefined,
             description: js.UndefOr[String] = js.undefined,
             enableMouseTracking: js.UndefOr[Boolean] = js.undefined,

--- a/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/treemap/SeriesTreemap.scala
+++ b/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/treemap/SeriesTreemap.scala
@@ -147,7 +147,7 @@ object SeriesTreemap {
             colors: js.UndefOr[Seq[Color]] = js.undefined,
             cropThreshold: js.UndefOr[Double] = js.undefined,
             cursor: js.UndefOr[String] = js.undefined,
-            data: Seq[SeriesTreemapData | Double] = Seq.empty,
+            data: Seq[Double | SeriesTreemapData] = Seq.empty,
             dataLabels: js.UndefOr[SeriesDataLabels] = js.undefined,
             description: js.UndefOr[String] = js.undefined,
             enableMouseTracking: js.UndefOr[Boolean] = js.undefined,

--- a/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/waterfall/SeriesWaterfall.scala
+++ b/charts/.js/src/main/scala/io/udash/wrappers/highcharts/config/series/waterfall/SeriesWaterfall.scala
@@ -119,7 +119,7 @@ object SeriesWaterfall {
             crisp: js.UndefOr[Boolean] = js.undefined,
             cursor: js.UndefOr[String] = js.undefined,
             dashStyle: js.UndefOr[DashStyle] = js.undefined,
-            data: Seq[SeriesWaterfallData | Double] = Seq.empty,
+            data: Seq[Double | js.Array[Double] | SeriesWaterfallData] = Seq.empty,
             dataLabels: js.UndefOr[SeriesDataLabels] = js.undefined,
             description: js.UndefOr[String] = js.undefined,
             depth: js.UndefOr[Double] = js.undefined,


### PR DESCRIPTION
This PR aligns the `data` argument for all chart series with the docs
in terms of order in the union type and the ability to directly pass
2D arrays where applicable.

This is not only beneficial in terms of performance, but also enables
larger datasets when the size surpasses `turboThreshold` (while named
values are not necessary)