### PR TITLE
Tempus Dominus date picker fixes

### DIFF
--- a/bootstrap4/.js/src/main/scala/io/udash/bootstrap/datepicker/UdashDatePicker.scala
+++ b/bootstrap4/.js/src/main/scala/io/udash/bootstrap/datepicker/UdashDatePicker.scala
@@ -13,7 +13,8 @@ import io.udash.css.{CssStyle, CssStyleName}
 import io.udash.i18n.{LangProperty, TranslationKey0, TranslationProvider}
 import io.udash.logging.CrossLogging
 import io.udash.wrappers.jquery._
-import org.scalajs.dom.Element
+import org.scalajs.dom.raw.{MutationObserver, MutationObserverInit}
+import org.scalajs.dom.{Element, document}
 
 import scala.scalajs.js
 import scala.scalajs.js.|
@@ -37,6 +38,24 @@ final class UdashDatePicker private[datepicker](
   ).render
   private val jQInput = jQ(inp).asInstanceOf[UdashDatePickerJQuery]
 
+  locally {
+    // When a date picker gets appended to a DOM, its options and listeners should be initialized once again. Thus, all
+    // nodes with mutated children are examined whether there is a date picker defined within a corresponding DOM
+    // subtree. It is also substantially possible for any date picker to be reported by more than one `MutationRecord`
+    // since the `subtree` switch of `MutationObserverInit` is on, thus only the first update is considered (note
+    // `findOpt`) to avoid double initialization.
+    new MutationObserver((records, _) =>
+      records
+        .iterator
+        .flatMap(record => for {i <- 0 until record.addedNodes.length} yield record.addedNodes(i))
+        .findOpt {
+          case element: Element => element.querySelector(s"#$componentId") != null
+          case _ => false
+        }
+        .foreach(_ => setupDatePicker())
+    ).observe(document.body, MutationObserverInit(childList = true, subtree = true))
+  }
+
   /** Shows date picker widget. */
   def show(): Unit =
     jQInput.datetimepicker("show")
@@ -57,47 +76,47 @@ final class UdashDatePicker private[datepicker](
   def disable(): Unit =
     jQInput.datetimepicker("disable")
 
-  val render: Element = {
-    jQInput.datetimepicker(optionsToJsDict(options.get))
-
-    propertyListeners += options.listen { opts =>
-      optionsToJsDict(opts).foreach { case (key, value) =>
-        jQInput.datetimepicker(key, value)
-      }
-    }
-
-    date.get.foreach(d => jQInput.datetimepicker("date", dateToMoment(d)))
-    propertyListeners += date.listen(op => op.foreach(d => jQInput.datetimepicker("date", dateToMoment(d))))
-
-    nestedInterceptor(new JQueryOnBinding(jQInput, "change.datetimepicker", (_: Element, ev: JQueryEvent) => {
-      val event = ev.asInstanceOf[DatePickerChangeJQEvent]
-      val dateOption = event.option.flatMap(ev => sanitizeDate(ev.date)).map(momentToDate)
-      val oldDateOption = date.get
-      if (dateOption != oldDateOption) {
-        dateOption match {
-          case Some(null) => date.set(None)
-          case Some(d) => date.set(Option(d))
-          case None => date.set(None)
-        }
-        fire(UdashDatePicker.DatePickerEvent.Change(this, dateOption, oldDateOption))
-      }
-    }))
-    nestedInterceptor(new JQueryOnBinding(jQInput, "hide.datetimepicker", (_: Element, ev: JQueryEvent) => {
-      fire(UdashDatePicker.DatePickerEvent.Hide(this, date.get))
-    }))
-    nestedInterceptor(new JQueryOnBinding(jQInput, "show.datetimepicker", (_: Element, ev: JQueryEvent) => {
-      fire(UdashDatePicker.DatePickerEvent.Show(this))
-    }))
-    nestedInterceptor(new JQueryOnBinding(jQInput, "error.datetimepicker", (_: Element, ev: JQueryEvent) => {
-      fire(UdashDatePicker.DatePickerEvent.Error(this, date.get))
-    }))
-
+  override val render: Element = {
+    propertyListeners += options.listen(opts =>
+      optionsToJsDict(opts).foreach { case (optionKey, optionValue) => jQInput.datetimepicker(optionKey, optionValue) }
+    )
+    propertyListeners += date.listen(optionalDate => optionalDate.foreach(date => jQInput.datetimepicker("date", dateToMoment(date))))
     inp
   }
 
   override def kill(): Unit = {
     super.kill()
     jQInput.datetimepicker("destroy")
+  }
+
+  private def setupDatePicker(): Unit = {
+    jQInput.datetimepicker(
+      optionsToJsDict(options.get)
+        .setup(optionsDict => date.get.foreach(date => optionsDict.update("date", dateToMoment(date))))
+    )
+
+    nestedInterceptor(new JQueryOnBinding(jQInput, "change.datetimepicker", (_: Element, event: JQueryEvent) => {
+      val dateOption = event.asInstanceOf[DatePickerChangeJQEvent].option
+        .flatMap(ev => sanitizeDate(ev.date))
+        .map(momentToDate)
+      val oldDateOption = date.get
+      if (dateOption != oldDateOption) {
+        dateOption match {
+          case Some(null) | None => date.set(None)
+          case _ => date.set(dateOption)
+        }
+        fire(UdashDatePicker.DatePickerEvent.Change(this, dateOption, oldDateOption))
+      }
+    }))
+    nestedInterceptor(new JQueryOnBinding(jQInput, "hide.datetimepicker", (_: Element, _: JQueryEvent) => {
+      fire(UdashDatePicker.DatePickerEvent.Hide(this, date.get))
+    }))
+    nestedInterceptor(new JQueryOnBinding(jQInput, "show.datetimepicker", (_: Element, _: JQueryEvent) => {
+      fire(UdashDatePicker.DatePickerEvent.Show(this))
+    }))
+    nestedInterceptor(new JQueryOnBinding(jQInput, "error.datetimepicker", (_: Element, _: JQueryEvent) => {
+      fire(UdashDatePicker.DatePickerEvent.Error(this, date.get))
+    }))
   }
 
   private def optionsToJsDict(options: UdashDatePicker.DatePickerOptions): js.Dictionary[js.Any] = {

--- a/bootstrap4/.js/src/main/scala/io/udash/bootstrap/datepicker/UdashDatePicker.scala
+++ b/bootstrap4/.js/src/main/scala/io/udash/bootstrap/datepicker/UdashDatePicker.scala
@@ -98,9 +98,9 @@ final class UdashDatePicker private[datepicker](
   }
 
   override def kill(): Unit = {
-    super.kill()
     deregisterSetupCallback(componentId)
     jQInput.datetimepicker("destroy")
+    super.kill()
   }
 
   private def optionsToJsDict(options: UdashDatePicker.DatePickerOptions): js.Dictionary[js.Any] = {
@@ -535,9 +535,9 @@ object UdashDatePicker {
   }
 
   import org.scalajs.dom.raw.{MutationObserver, MutationObserverInit, MutationRecord}
-  import scala.collection.mutable.{Set => MSet}
+  import scala.collection.mutable.{Map => MMap}
 
-  private val datePickerSetupCallbacks = MSet.empty[(ComponentId, () => Unit)]
+  private val datePickerSetupCallbacks = MMap.empty[ComponentId, () => Unit]
 
   // When a date picker gets appended to a DOM, its options and listeners should be initialized once again. Thus, all
   // nodes with mutated children are examined whether there is a date picker defined within a corresponding DOM
@@ -557,13 +557,13 @@ object UdashDatePicker {
     })
 
   def registerSetupCallback(id: ComponentId, callback: () => Unit): Unit = {
-    datePickerSetupCallbacks += ((id, callback))
     if (datePickerSetupCallbacks.isEmpty)
       datePickerMutationObserver.observe(document.body, MutationObserverInit(childList = true, subtree = true))
+    datePickerSetupCallbacks += (id -> callback)
   }
 
   def deregisterSetupCallback(id: ComponentId): Unit = {
-    datePickerSetupCallbacks.findOpt { case (pickerId, _) => pickerId == id }.foreach(datePickerSetupCallbacks -= _)
+    datePickerSetupCallbacks -= id
     if (datePickerSetupCallbacks.isEmpty)
       datePickerMutationObserver.disconnect()
   }

--- a/bootstrap4/.js/src/test/scala/io/udash/bootstrap/datepicker/UdashDatePickerTest.scala
+++ b/bootstrap4/.js/src/test/scala/io/udash/bootstrap/datepicker/UdashDatePickerTest.scala
@@ -102,7 +102,7 @@ class UdashDatePickerTest extends AsyncUdashCoreFrontendTest {
         ).render
       )
       noException shouldBe thrownBy {
-        jQ("#" + picker.componentId.id).asInstanceOf[JQueryDatePickerExt].datetimepicker("date", null)
+        jQ(() => jQ("#" + picker.componentId.id).asInstanceOf[JQueryDatePickerExt].datetimepicker("date", null))
       }
     }
 
@@ -125,7 +125,7 @@ class UdashDatePickerTest extends AsyncUdashCoreFrontendTest {
 
       for {
         _ <- {
-          pickerJQ.datetimepicker("date", "May 15th 2017, 10:59 am")
+          jQ(() => pickerJQ.datetimepicker("date", "May 15th 2017, 10:59 am"))
           retrying {
             // ignore time zone
             date.get.get.getTime should be > 1494763200000L
@@ -133,7 +133,7 @@ class UdashDatePickerTest extends AsyncUdashCoreFrontendTest {
           }
         }
         r <- {
-          pickerJQ.datetimepicker("date", null)
+          jQ(() => pickerJQ.datetimepicker("date", null))
           retrying {
             date.get should be(None)
           }
@@ -166,37 +166,37 @@ class UdashDatePickerTest extends AsyncUdashCoreFrontendTest {
 
       for {
         _ <- {
-          date.set(Some(new ju.Date(3000000000L)))
+          jQ(() => date.set(Some(new ju.Date(3000000000L))))
           retrying {
             (errorCounter, changeCounter) should be((0, 1))
           }
         }
         _ <- {
-          date.set(Some(new ju.Date(300000)))
+          jQ(() => date.set(Some(new ju.Date(300000))))
           retrying {
             (errorCounter, changeCounter) should be((1, 1))
           }
         }
         _ <- {
-          date.set(Some(new ju.Date(2000000000L)))
+          jQ(() => date.set(Some(new ju.Date(2000000000L))))
           retrying {
             (errorCounter, changeCounter) should be((1, 2))
           }
         }
         _ <- {
-          date.set(Some(new ju.Date(8000000000L)))
+          jQ(() => date.set(Some(new ju.Date(8000000000L))))
           retrying {
             (errorCounter, changeCounter) should be((2, 2))
           }
         }
         _ <- {
-          date.set(Some(new ju.Date(3000000000L)))
+          jQ(() => date.set(Some(new ju.Date(3000000000L))))
           retrying {
             (errorCounter, changeCounter) should be((2, 3))
           }
         }
         r <- {
-          date.set(Some(new ju.Date(4000000000L)))
+          jQ(() => date.set(Some(new ju.Date(4000000000L))))
           retrying {
             (errorCounter, changeCounter) should be((2, 4))
           }
@@ -262,4 +262,3 @@ private trait JQueryDatePickerExt extends JQuery {
   def datetimepicker(function: String): js.Any = js.native
   def datetimepicker(option: String, value: js.Any): JQueryDatePickerExt = js.native
 }
-


### PR DESCRIPTION
Done:
 - date picker options and listeners are initialized on DOM append to enable caching component's state,
 - single `datetimepicker` call with both options and default date (avoiding stack overflow errors),
 - minor refactoring.