### PR TITLE
Date Range Picker and List Group BS Guides restoration

### DIFF
--- a/guide/guide/.js/src/main/scala/io/udash/web/guide/views/ext/demo/bootstrap/DateRangePickerDemo.scala
+++ b/guide/guide/.js/src/main/scala/io/udash/web/guide/views/ext/demo/bootstrap/DateRangePickerDemo.scala
@@ -49,7 +49,6 @@ object DateRangePickerDemo extends AutoDemo with CssView {
   }.withSourceCode
 
   override protected def demoWithSource(): (Modifier, Iterator[String]) = {
-    (rendered.applyTags(GuideStyles.frame), source.linesIterator)
+    (rendered.setup(_.applyTags(GuideStyles.frame)), source.linesIterator)
   }
 }
-

--- a/guide/guide/.js/src/main/scala/io/udash/web/guide/views/ext/demo/bootstrap/ListGroupDemo.scala
+++ b/guide/guide/.js/src/main/scala/io/udash/web/guide/views/ext/demo/bootstrap/ListGroupDemo.scala
@@ -43,7 +43,6 @@ object ListGroupDemo extends AutoDemo with CssView {
   }.withSourceCode
 
   override protected def demoWithSource(): (Modifier, Iterator[String]) = {
-    (rendered.applyTags(GuideStyles.frame), source.linesIterator)
+    (rendered.setup(_.applyTags(GuideStyles.frame)), source.linesIterator)
   }
 }
-


### PR DESCRIPTION
Macro-generated Bootstrap Guides, which disappeared after #284, restored.