### PR TITLE
Support dynamic dropdown items

### DIFF
--- a/bootstrap4/.js/src/main/scala/io/udash/bootstrap/dropdown/UdashDropdown.scala
+++ b/bootstrap4/.js/src/main/scala/io/udash/bootstrap/dropdown/UdashDropdown.scala
@@ -78,7 +78,7 @@ final class UdashDropdown[ItemType, ElemType <: ReadableProperty[ItemType]] priv
         nestedInterceptor(BootstrapStyles.Dropdown.menuRight.styleIf(rightAlignMenu)),
         aria.labelledby := buttonId, id := menuId
       )(nestedInterceptor(
-        produce(items.transform((item: ItemType) => withSelectionListener(itemFactory(item, nestedInterceptor), item)))(el => el)
+        produceWithNested(items)((items, nested) => items.map(item => withSelectionListener(itemFactory(item, nested), item)))
       ))
     ).render
 

--- a/bootstrap4/.js/src/test/scala/io/udash/bootstrap/dropdown/UdashDropdownTest.scala
+++ b/bootstrap4/.js/src/test/scala/io/udash/bootstrap/dropdown/UdashDropdownTest.scala
@@ -87,7 +87,7 @@ class UdashDropdownTest extends UdashCoreFrontendTest {
 
     "call listeners on element click" in {
       val els = SeqProperty(elements)
-      val dropdown = UdashDropdown(els)(UdashDropdown.defaultItemFactory, "Test")
+      val dropdown = UdashDropdown.default(els)("Test")
       val el = dropdown.render
       jQ("body").append(el)
 

--- a/guide/guide/.js/src/main/scala/io/udash/web/guide/views/ext/demo/bootstrap/ButtonDropdownDemo.scala
+++ b/guide/guide/.js/src/main/scala/io/udash/web/guide/views/ext/demo/bootstrap/ButtonDropdownDemo.scala
@@ -32,16 +32,10 @@ object ButtonDropdownDemo extends AutoDemo with CssView {
       UdashButtonToolbar()(
         UdashButtonGroup()(
           UdashButton()("Button").render,
-          UdashDropdown(items)(
-            defaultItemFactory, _ => ""
-          ).render,
-          UdashDropdown(items, Direction.Up.toProperty)(
-            defaultItemFactory, _ => ""
-          ).render
+          UdashDropdown.default(items)(_ => "").render,
+          UdashDropdown.default(items, Direction.Up.toProperty)(_ => "").render
         ).render,
-        UdashDropdown(items)(
-          defaultItemFactory, _ => "Dropdown "
-        ).render
+        UdashDropdown.default(items)(_ => "Dropdown ").render
       )
     ).render
   }.withSourceCode

--- a/guide/guide/.js/src/main/scala/io/udash/web/guide/views/ext/demo/bootstrap/DropdownsDemo.scala
+++ b/guide/guide/.js/src/main/scala/io/udash/web/guide/views/ext/demo/bootstrap/DropdownsDemo.scala
@@ -40,20 +40,8 @@ object DropdownsDemo extends AutoDemo with CrossLogging {
     }, 5000)
     window.setTimeout(() => window.clearInterval(appendHandler), 60000)
 
-    val dropdown = UdashDropdown(items)(
-      UdashDropdown.defaultItemFactory,
-      _ => Seq[Modifier](
-        "Dropdown ",
-        Button.color(Color.Primary)
-      )
-    )
-    val dropup = UdashDropdown(
-      items,
-      UdashDropdown.Direction.Up.toProperty
-    )(
-      UdashDropdown.defaultItemFactory,
-      _ => "Dropup "
-    )
+    val dropdown = UdashDropdown.default(items)(_ => Seq[Modifier]("Dropdown ", Button.color(Color.Primary)))
+    val dropup = UdashDropdown.default(items, UdashDropdown.Direction.Up.toProperty)(_ => "Dropup ")
 
     Seq(dropdown, dropup).foreach(_.listen {
       case UdashDropdown.DropdownEvent.SelectionEvent(_, item) =>

--- a/guide/guide/.js/src/main/scala/io/udash/web/guide/views/ext/demo/bootstrap/NavigationDemo.scala
+++ b/guide/guide/.js/src/main/scala/io/udash/web/guide/views/ext/demo/bootstrap/NavigationDemo.scala
@@ -35,7 +35,7 @@ object NavigationDemo extends AutoDemo {
         elemFactory = (panel, nested) => div(nested(produce(panel) {
           case MenuContainer(name, children) =>
             val dropdown = UdashDropdown(SeqProperty(children))(
-              linkFactory(_),
+              (link, _) => linkFactory(link),
               _ => span(name, " ")
             ).render
             dropdown.firstElementChild.applyTags(Navigation.link)

--- a/guide/guide/.js/src/main/scala/io/udash/web/guide/views/ext/demo/bootstrap/NavigationDemo.scala
+++ b/guide/guide/.js/src/main/scala/io/udash/web/guide/views/ext/demo/bootstrap/NavigationDemo.scala
@@ -34,8 +34,8 @@ object NavigationDemo extends AutoDemo {
       )(_ => UdashNav(panels)(
         elemFactory = (panel, nested) => div(nested(produce(panel) {
           case MenuContainer(name, children) =>
-            val dropdown = UdashDropdown(SeqProperty(children))(
-              (link, _) => linkFactory(link),
+            val dropdown = UdashDropdown(children.toSeqProperty)(
+              (item, _) => linkFactory(item.get),
               _ => span(name, " ")
             ).render
             dropdown.firstElementChild.applyTags(Navigation.link)


### PR DESCRIPTION
The initial idea behind https://github.com/UdashFramework/udash-core/commit/79783e21a362445506a641e35c48f739389adb57 was to avoid additional `<span>` element polluting the DOM in the typical, non-dynamic case. My proposal for the middle-ground between the original version and the current one is to introduce limited support which would push the responsibility for creating a wrapping `Element` to the API user.

Closes #379 