### PR TITLE
Update artifact ID for Bootstrap extensions

### DIFF
--- a/guide/guide/.js/src/main/scala/io/udash/web/guide/views/ext/BootstrapExtView.scala
+++ b/guide/guide/.js/src/main/scala/io/udash/web/guide/views/ext/BootstrapExtView.scala
@@ -55,7 +55,7 @@ class BootstrapExtView extends FinalView {
     h2("First steps"),
     p("To start development with the Bootstrap wrapper add the following line in you frontend module dependencies: "),
     CodeBlock(
-      s""""io.udash" %%% "udash-bootstrap" % "${Versions.udashVersion}"""".stripMargin
+      s""""io.udash" %%% "udash-bootstrap4" % "${Versions.udashVersion}"""".stripMargin
     )(GuideStyles),
     p("The wrapper provides a typed equivalent of the ", a(href := References.BootstrapHomepage, target := "_blank")("Twitter Bootstrap"), " API."),
     h2("Statics"),


### PR DESCRIPTION
The demos are based on the B4 module, whereas the dependency
(and template generator https://github.com/UdashFramework/udash.g8/issues/17)
still mentions the old, B3 based module.