### PR TITLE
Cookie names and values are URL-encoded

### DIFF
--- a/guide/guide/.js/src/main/assets/pages/rest.md
+++ b/guide/guide/.js/src/main/assets/pages/rest.md
@@ -617,9 +617,10 @@ primitive types, its Java boxed counterparts, `String`, all `NamedEnum`s, Java e
 It's also easy to provide path/query/header serialization for any type which has a natural, unambiguous textual
 representation.
 
-Serialized values of path & query parameters are automatically URL-encoded when being embedded into
+Serialized values of path, query and cookie parameters are automatically URL-encoded when being embedded into
 HTTP requests. This means that serialization should not worry about that.
-Cookie parameter values must not contain ';' character (semicolon).
+URL-encoding is also applied to query and cookie parameter _names_, in both actual HTTP requests and
+[OpenAPI documents](#generating-openapi-30-specifications).
 
 ### Body parameter serialization
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Dependencies {
 
   val scalaLoggingVersion = "3.9.2"
 
-  val jettyVersion = "9.4.20.v20190813" // Tests only
+  val jettyVersion = "9.4.21.v20190926"
   val typesafeConfigVersion = "1.4.0"
   val flexmarkVersion = "0.50.40"
   val logbackVersion = "1.2.3"

--- a/rest/.jvm/src/main/scala/io/udash/rest/RestServlet.scala
+++ b/rest/.jvm/src/main/scala/io/udash/rest/RestServlet.scala
@@ -8,6 +8,7 @@ import com.avsystem.commons.annotation.explicitGenerics
 import com.typesafe.scalalogging.LazyLogging
 import io.udash.rest.RestServlet._
 import io.udash.rest.raw._
+import io.udash.utils.URLEncoder
 import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse}
 import javax.servlet.{AsyncEvent, AsyncListener}
 
@@ -85,9 +86,13 @@ class RestServlet(
     }
     val headers = headersBuilder.result()
 
-    val cookies = request.getHeaders(CookieHeader).asScala.foldLeft(Mapping.empty[PlainValue]) {
-      (cookies, headerValue) => cookies ++ PlainValue.decodeCookies(headerValue)
+    val cookiesBuilder = Mapping.newBuilder[PlainValue]
+    request.getCookies.opt.getOrElse(Array.empty).foreach { cookie =>
+      val cookieName = URLEncoder.decode(cookie.getName, plusAsSpace = true)
+      val cookieValue = URLEncoder.decode(cookie.getValue, plusAsSpace = true)
+      cookiesBuilder += cookieName -> PlainValue(cookieValue)
     }
+    val cookies = cookiesBuilder.result()
 
     RestParameters(path, headers, query, cookies)
   }

--- a/rest/.jvm/src/main/scala/io/udash/rest/RestServlet.scala
+++ b/rest/.jvm/src/main/scala/io/udash/rest/RestServlet.scala
@@ -20,13 +20,13 @@ object RestServlet {
   final val CookieHeader = "Cookie"
 
   /**
-    * Wraps an implementation of some REST API trait into a Java Servlet.
-    *
-    * @param apiImpl        implementation of some REST API trait
-    * @param handleTimeout  maximum time the servlet will wait for results returned by REST API implementation
-    * @param maxPayloadSize maximum acceptable incoming payload size, in bytes;
-    *                       if exceeded, `413 Payload Too Large` response will be sent back
-    */
+   * Wraps an implementation of some REST API trait into a Java Servlet.
+   *
+   * @param apiImpl        implementation of some REST API trait
+   * @param handleTimeout  maximum time the servlet will wait for results returned by REST API implementation
+   * @param maxPayloadSize maximum acceptable incoming payload size, in bytes;
+   *                       if exceeded, `413 Payload Too Large` response will be sent back
+   */
   @explicitGenerics def apply[RestApi: RawRest.AsRawRpc : RestMetadata](
     apiImpl: RestApi,
     handleTimeout: FiniteDuration = DefaultHandleTimeout,
@@ -74,7 +74,9 @@ class RestServlet(
     // can't use request.getPathInfo because it decodes the URL before we can split it
     val pathPrefix = request.getContextPath.orEmpty + request.getServletPath.orEmpty
     val path = PlainValue.decodePath(request.getRequestURI.stripPrefix(pathPrefix))
+
     val query = request.getQueryString.opt.map(PlainValue.decodeQuery).getOrElse(Mapping.empty)
+
     val headersBuilder = IMapping.newBuilder[PlainValue]
     request.getHeaderNames.asScala.foreach { headerName =>
       if (!headerName.equalsIgnoreCase(CookieHeader)) { // cookies are separate, don't include them into header params
@@ -82,11 +84,11 @@ class RestServlet(
       }
     }
     val headers = headersBuilder.result()
-    val cookiesBuilder = Mapping.newBuilder[PlainValue]
-    request.getCookies.opt.getOrElse(Array.empty).foreach { cookie =>
-      cookiesBuilder += cookie.getName -> PlainValue(cookie.getValue)
+
+    val cookies = request.getHeaders(CookieHeader).asScala.foldLeft(Mapping.empty[PlainValue]) {
+      (cookies, headerValue) => cookies ++ PlainValue.decodeCookies(headerValue)
     }
-    val cookies = cookiesBuilder.result()
+
     RestParameters(path, headers, query, cookies)
   }
 

--- a/rest/.jvm/src/test/resources/RestTestApi.json
+++ b/rest/.jvm/src/test/resources/RestTestApi.json
@@ -327,7 +327,7 @@
             }
           },
           {
-            "name": "q=2",
+            "name": "q%3D2",
             "in": "query",
             "explode": false,
             "schema": {
@@ -346,7 +346,7 @@
             }
           },
           {
-            "name": "coo",
+            "name": "c%C3%B3",
             "in": "cookie",
             "required": true,
             "explode": false,
@@ -416,7 +416,7 @@
             }
           },
           {
-            "name": "q=2",
+            "name": "q%3D2",
             "in": "query",
             "required": true,
             "explode": false,

--- a/rest/jetty/src/main/scala/io/udash/rest/jetty/JettyRestClient.scala
+++ b/rest/jetty/src/main/scala/io/udash/rest/jetty/JettyRestClient.scala
@@ -7,6 +7,7 @@ import java.nio.charset.Charset
 import com.avsystem.commons._
 import com.avsystem.commons.annotation.explicitGenerics
 import io.udash.rest.raw._
+import io.udash.utils.URLEncoder
 import org.eclipse.jetty.client.HttpClient
 import org.eclipse.jetty.client.api.Result
 import org.eclipse.jetty.client.util.{BufferingResponseListener, BytesContentProvider, StringContentProvider}
@@ -46,7 +47,8 @@ object JettyRestClient {
           case (name, PlainValue(value)) => httpReq.header(name, value)
         }
         request.parameters.cookies.entries.foreach {
-          case (name, PlainValue(value)) => httpReq.cookie(new HttpCookie(name, value))
+          case (name, PlainValue(value)) => httpReq.cookie(new HttpCookie(
+            URLEncoder.encode(name, spaceAsPlus = true), URLEncoder.encode(value, spaceAsPlus = true)))
         }
 
         request.body match {

--- a/rest/src/main/scala/io/udash/rest/SttpRestClient.scala
+++ b/rest/src/main/scala/io/udash/rest/SttpRestClient.scala
@@ -14,18 +14,18 @@ object SttpRestClient {
   def defaultBackend(): SttpBackend[Future, Nothing] = DefaultSttpBackend()
 
   /**
-    * Creates a client instance of some REST API trait which translates method calls into HTTP requests
-    * to given URI using STTP.
-    */
+   * Creates a client instance of some REST API trait which translates method calls into HTTP requests
+   * to given URI using STTP.
+   */
   @explicitGenerics def apply[RestApi: RawRest.AsRealRpc : RestMetadata](baseUri: String)(
     implicit backend: SttpBackend[Future, Nothing]
   ): RestApi =
     RawRest.fromHandleRequest[RestApi](asHandleRequest(baseUri))
 
   /**
-    * Creates a [[io.udash.rest.raw.RawRest.HandleRequest HandleRequest]] function which sends REST requests to
-    * a specified base URI using default HTTP client implementation (sttp).
-    */
+   * Creates a [[io.udash.rest.raw.RawRest.HandleRequest HandleRequest]] function which sends REST requests to
+   * a specified base URI using default HTTP client implementation (sttp).
+   */
   def asHandleRequest(baseUri: String)(implicit backend: SttpBackend[Future, Nothing]): RawRest.HandleRequest =
     asHandleRequest(uri"$baseUri")
 
@@ -45,17 +45,11 @@ object SttpRestClient {
         List((HeaderNames.ContentType, neBody.contentType))
     }
 
-    val paramHeaders = request.parameters.headers.entries.iterator.map {
-      case (n, PlainValue(v)) => (n, v)
-    }.toList
+    val paramHeaders = request.parameters.headers.entries.iterator
+      .map { case (n, PlainValue(v)) => (n, v) }.toList
 
-    val cookieHeaders = List(request.parameters.cookies.entries).filter(_.nonEmpty).map { cookies =>
-      "Cookie" -> cookies.iterator.map {
-        case (n, PlainValue(v)) =>
-          require(!v.contains(";"), s"invalid cookie: $n=$v")
-          s"$n=$v"
-      }.mkString(";")
-    }
+    val cookieHeaders = List(request.parameters.cookies).filter(_.nonEmpty)
+      .map(cookies => "Cookie" -> PlainValue.encodeCookies(cookies))
 
     val paramsRequest =
       sttp.method(Method(request.method.name), uri)

--- a/rest/src/main/scala/io/udash/rest/SttpRestClient.scala
+++ b/rest/src/main/scala/io/udash/rest/SttpRestClient.scala
@@ -11,6 +11,8 @@ import io.udash.rest.raw._
 import scala.concurrent.Future
 
 object SttpRestClient {
+  final val CookieHeader = "Cookie"
+
   def defaultBackend(): SttpBackend[Future, Nothing] = DefaultSttpBackend()
 
   /**
@@ -49,7 +51,7 @@ object SttpRestClient {
       .map { case (n, PlainValue(v)) => (n, v) }.toList
 
     val cookieHeaders = List(request.parameters.cookies).filter(_.nonEmpty)
-      .map(cookies => RestServlet.CookieHeader -> PlainValue.encodeCookies(cookies))
+      .map(cookies => CookieHeader -> PlainValue.encodeCookies(cookies))
 
     val paramsRequest =
       sttp.method(Method(request.method.name), uri)

--- a/rest/src/main/scala/io/udash/rest/SttpRestClient.scala
+++ b/rest/src/main/scala/io/udash/rest/SttpRestClient.scala
@@ -49,7 +49,7 @@ object SttpRestClient {
       .map { case (n, PlainValue(v)) => (n, v) }.toList
 
     val cookieHeaders = List(request.parameters.cookies).filter(_.nonEmpty)
-      .map(cookies => "Cookie" -> PlainValue.encodeCookies(cookies))
+      .map(cookies => RestServlet.CookieHeader -> PlainValue.encodeCookies(cookies))
 
     val paramsRequest =
       sttp.method(Method(request.method.name), uri)

--- a/rest/src/main/scala/io/udash/rest/openapi/OpenApiMetadata.scala
+++ b/rest/src/main/scala/io/udash/rest/openapi/OpenApiMetadata.scala
@@ -7,6 +7,7 @@ import com.avsystem.commons.rpc._
 import io.udash.rest.openapi.adjusters._
 import io.udash.rest.raw._
 import io.udash.rest.{Header => HeaderAnnot, _}
+import io.udash.utils.URLEncoder
 
 import scala.annotation.implicitNotFound
 import scala.collection.mutable
@@ -250,7 +251,9 @@ final case class OpenApiParameter[T](
       case _: Cookie => Location.Cookie
     }
     val pathParam = in == Location.Path
-    val param = Parameter(info.name, in,
+    val urlEncodeName = in == Location.Query || in == Location.Cookie
+    val name = if(urlEncodeName) URLEncoder.encode(info.name, spaceAsPlus = true) else info.name
+    val param = Parameter(name, in,
       required = pathParam || !info.hasFallbackValue,
       schema = info.schema(resolver, withDefaultValue = !pathParam),
       // repeated query/cookie/header params are not supported for now so ensure `explode` is never assumed to be true

--- a/rest/src/test/scala/io/udash/rest/RestTestApi.scala
+++ b/rest/src/test/scala/io/udash/rest/RestTestApi.scala
@@ -80,7 +80,7 @@ trait RestTestApi {
     @Path("p1") p1: Int, @description("Very serious path parameter") @title("Stri") @Path p2: String,
     @Header("X-H1") h1: Int, @Header("X-H2") h2: String,
     q1: Int, @Query("q=2") @whenAbsent("q2def") q2: String = whenAbsent.value,
-    @Cookie c1: Int, @Cookie("coo") c2: String
+    @Cookie c1: Int, @Cookie("có") c2: String
   ): Future[RestEntity]
 
   @POST("multi/param") def multiParamPost(


### PR DESCRIPTION
This fixes the problem encountered by #410 where Jetty started having problems with cookies containing non-ascii characters. Cookies are notoriously ill-specified and there's no real accepted and implemented standard for them: https://stackoverflow.com/questions/1969232/allowed-characters-in-cookies

This is technically a breaking change but IMHO the chance of this affecting anyone is slim because:
* cookies are rarely used
* cookies with characters which need URL-encoding are even less probable
* projects using Udash REST on both client and server side will be fine as long as both sides are using the same version of Udash REST