### PR TITLE
Supress non-forced updates on transformed properties

### DIFF
--- a/core/src/main/scala/io/udash/properties/single/TransformedProperty.scala
+++ b/core/src/main/scala/io/udash/properties/single/TransformedProperty.scala
@@ -1,10 +1,8 @@
 package io.udash.properties
 package single
 
-import com.avsystem.commons.misc.Opt
+import com.avsystem.commons._
 import io.udash.utils.Registration
-
-import scala.concurrent.Future
 
 /** Represents ReadableProperty[A] transformed to ReadableProperty[B]. */
 private[properties] class TransformedReadableProperty[A, B](
@@ -16,15 +14,21 @@ private[properties] class TransformedReadableProperty[A, B](
   protected var originListenerRegistration: Registration = _
 
   protected def originListener(originValue: A) : Unit = {
-    lastValue = Opt(originValue)
-    transformedValue = transformer(originValue)
-    fireValueListeners()
+    val forced = lastValue.contains(originValue) //if the listener was triggered despite equal value, the update was forced
+    val newValue = transformer(originValue)
+    val transformedValueChanged = newValue != transformedValue
+    lastValue = originValue.opt
+    transformedValue = newValue
+    if (forced || transformedValueChanged) fireValueListeners()
   }
 
   private def initOriginListener(): Unit = {
     if (originListenerRegistration == null || !originListenerRegistration.isActive) {
       listeners.clear()
       originListenerRegistration = origin.listen(originListener)
+      val originValue = origin.get
+      lastValue = originValue.opt
+      lastValue.foreach(v => transformedValue = transformer(v))
     }
   }
 
@@ -63,7 +67,7 @@ private[properties] class TransformedReadableProperty[A, B](
 
   override def get: B = {
     val originValue = origin.get
-    if (lastValue.isEmpty || lastValue.get != originValue) {
+    if (originListenerRegistration == null && (lastValue.isEmpty || lastValue.get != originValue)) {
       lastValue = Opt(originValue)
       transformedValue = transformer(originValue)
     }

--- a/core/src/test/scala/io/udash/properties/PropertyTest.scala
+++ b/core/src/test/scala/io/udash/properties/PropertyTest.scala
@@ -339,6 +339,28 @@ class PropertyTest extends UdashCoreTest {
       counter shouldBe 2
     }
 
+    "fire on streamed value changed or when forced" in {
+      val origin: Property[Option[Int]] = Property(Some(0))
+      val target = Property.blank[Boolean]
+
+      origin.streamTo(target)((q: Option[Int]) => q.isDefined)
+      var counter = 0
+
+      target.listen(_ => counter += 1)
+
+      origin.set(Some(0))
+      counter shouldBe 0 //suppressed at origin
+
+      origin.set(Some(1))
+      counter shouldBe 0 //suppressed at target
+
+      origin.set(None)
+      counter shouldBe 1
+
+      origin.set(None)
+      counter shouldBe 1
+    }
+
     "combine with other properties (single properties)" in {
       val p1 = Property(1)
       val p2 = Property(2)
@@ -541,7 +563,7 @@ class PropertyTest extends UdashCoreTest {
 
       val p = Property("1,2,3,4,5")
       val s: ReadableSeqProperty[Int, ReadableProperty[Int]] =
-        p.transformToSeq((v: String) => Try(v.split(",").map(_.toInt).toSeq).getOrElse(Seq[Int]()))
+        p.transformToSeq((v: String) => Try(v.split(",").map(_.trim.toInt).toSeq).getOrElse(Seq[Int]()))
 
       p.listenersCount() should be(0)
 
@@ -566,6 +588,14 @@ class PropertyTest extends UdashCoreTest {
       lastPatch = null
       elementsUpdated = 0
       p.set("5,4,3")
+      s.get should be(Seq(5, 4, 3))
+      lastValue should be(s.get)
+      lastPatch.added.size should be(0)
+      lastPatch.removed.size should be(2)
+      elementsUpdated should be(2)
+
+      //suppressed at s
+      p.set(" 5 ,4 ,3")
       s.get should be(Seq(5, 4, 3))
       lastValue should be(s.get)
       lastPatch.added.size should be(0)

--- a/core/src/test/scala/io/udash/properties/PropertyTest.scala
+++ b/core/src/test/scala/io/udash/properties/PropertyTest.scala
@@ -337,6 +337,9 @@ class PropertyTest extends UdashCoreTest {
 
       origin.set(None, force = true)
       counter shouldBe 2
+
+      origin.touch()
+      counter shouldBe 3
     }
 
     "fire on streamed value changed or when forced" in {
@@ -359,6 +362,10 @@ class PropertyTest extends UdashCoreTest {
 
       origin.set(None)
       counter shouldBe 1
+
+      //todo detect forced / touched?
+      //origin.set(None, force = true)
+      //counter shouldBe 2
     }
 
     "combine with other properties (single properties)" in {

--- a/core/src/test/scala/io/udash/properties/PropertyTest.scala
+++ b/core/src/test/scala/io/udash/properties/PropertyTest.scala
@@ -316,6 +316,29 @@ class PropertyTest extends UdashCoreTest {
       counter2 should be(1)
     }
 
+    "fire on transformed value changed or when forced" in {
+      val origin: Property[Option[Int]] = Property(Some(0))
+      val transformed: ReadableProperty[Boolean] = origin.transform((q: Option[Int]) => q.isDefined)
+      var counter = 0
+
+      transformed.listen(_ => counter += 1)
+
+      origin.set(Some(0))
+      counter shouldBe 0 //suppressed at origin
+
+      origin.set(Some(1))
+      counter shouldBe 0 //suppressed at transformed
+
+      origin.set(None)
+      counter shouldBe 1
+
+      origin.set(None)
+      counter shouldBe 1
+
+      origin.set(None, force = true)
+      counter shouldBe 2
+    }
+
     "combine with other properties (single properties)" in {
       val p1 = Property(1)
       val p2 = Property(2)


### PR DESCRIPTION
Some of the property conversions (e.g. `streamTo`) do this by chance thanks to using an internal direct property. This was reported to be an performance issue in some cases.

There's a debatable part of this PR, where `.transform` detects forced update and behaves accordingly. We won't be able to do this uniformly for all cases though. Please give your view on this.