### PR TITLE
Introduced support of tags inside translation.

### DIFF
--- a/i18n/.js/src/main/scala/io/udash/i18n/bindings/package.scala
+++ b/i18n/.js/src/main/scala/io/udash/i18n/bindings/package.scala
@@ -1,0 +1,20 @@
+package io.udash.i18n
+
+import org.scalajs.dom._
+
+import scala.scalajs.js.{JavaScriptException, SyntaxError}
+import scala.util.{Failure, Success, Try}
+
+package object bindings {
+  def parseTranslation(rawHtml: Boolean, text: String): Seq[Node] =
+    if (rawHtml) Try {
+      val wrapper = document.createElement("div")
+      wrapper.innerHTML = text
+      wrapper.childNodes
+    } match {
+      case Success(children) if children.length > 0 =>
+        (0 until children.length).map(children.item)
+      case Success(_) | Failure(JavaScriptException(_: SyntaxError)) =>
+        Seq(document.createTextNode(text))
+    } else Seq(document.createTextNode(text))
+}

--- a/i18n/.js/src/main/scala/io/udash/i18n/package.scala
+++ b/i18n/.js/src/main/scala/io/udash/i18n/package.scala
@@ -1,7 +1,7 @@
 package io.udash
 
 import io.udash.bindings.modifiers.Binding
-import io.udash.i18n.bindings.{AttrTranslationBinding, DynamicAttrTranslationBinding, DynamicTranslationBinding, TranslationBinding}
+import io.udash.i18n.bindings._
 import org.scalajs.dom.Element
 import scalatags.JsDom.Modifier
 
@@ -14,25 +14,29 @@ package object i18n {
     property.get
 
   /**
-    * Binds translated string in DOM element.
-    * @param translation Future containing translated string or error.
-    * @param placeholder Placeholder, if `None` passed it will be empty text node.
-    */
-  def translated(translation: Future[Translated], placeholder: Option[Element] = None): Modifier =
-    new TranslationBinding(translation, placeholder)
+   * Binds translated string in DOM element.
+   * @param translation Future containing translated string or error.
+   * @param placeholder Placeholder, if `None` passed it will be empty text node.
+   * @param rawHtml Flag that force to use this translation as raw HTML, disabled by default
+   */
+  def translated(
+    translation: Future[Translated], placeholder: Option[Element] = None, rawHtml: Boolean = false
+  ): Modifier =
+    new TranslationBinding(translation, placeholder, rawHtml)
 
   /**
-    * Binds translated string in DOM element and updates it when application language changes.
-    * @param key TranslationKey which will be used in order to get text.
-    * @param translator Should apply any needed arguments to TranslationKey and create `Future[Translated]`.
-    * @param placeholder Placeholder, if `None` passed it will be empty text node.
-    */
+   * Binds translated string in DOM element and updates it when application language changes.
+   * @param key TranslationKey which will be used in order to get text.
+   * @param translator Should apply any needed arguments to TranslationKey and create `Future[Translated]`.
+   * @param placeholder Placeholder, if `None` passed it will be empty text node.
+   * @param rawHtml Flag that force to use this translation as raw HTML, disabled by default
+   */
   def translatedDynamic[Key <: TranslationKey](
-    key: Key, placeholder: Option[Element] = None
+    key: Key, placeholder: Option[Element] = None, rawHtml: Boolean = false
   )(
     translator: Key => Future[Translated]
   )(implicit lang: LangProperty): Binding =
-    new DynamicTranslationBinding(key, translator, placeholder)
+    new DynamicTranslationBinding(key, translator, placeholder, rawHtml)
 
   /**
     * Binds translated string in DOM element attribute.

--- a/i18n/.js/src/test/scala/io/udash/i18n/BindingsTest.scala
+++ b/i18n/.js/src/test/scala/io/udash/i18n/BindingsTest.scala
@@ -10,21 +10,24 @@ class BindingsTest extends AsyncUdashFrontendTest {
 
   implicit val provider: TranslationProvider = new LocalTranslationProvider(Map(
     Lang("en") -> Bundle(BundleHash("hash1"), Map(
+      "tr0" -> null,
       "tr1" -> "Translation {0}",
       "tr2" -> "Translation2 {1} {0}",
       "tr3" -> "Translation3 {}",
-      "tr4" -> "Translation4 {1} {} {}",
-      "tr5" -> "Translation5 {4}"
+      "tr4" -> "Translation4 <b>{1}</b> {} {}",
+      "tr5" -> "Translation5 <b>{4}</b>"
     )),
     Lang("pl") -> Bundle(BundleHash("hash1"), Map(
+      "tr0" -> null,
       "tr1" -> "Translation {0} pl",
       "tr2" -> "Translation2 {1} {0} pl",
       "tr3" -> "Translation3 {} pl",
-      "tr4" -> "Translation4 {1} {} {} pl",
-      "tr5" -> "Translation5 {4} pl"
+      "tr4" -> "Translation4 <b>{1}</b> {} {} pl",
+      "tr5" -> "Translation5 <b>{4}</b> pl"
     ))
   ), missingTranslationError = "ERROR")
 
+  val key0 = TranslationKey.keyX("tr0")
   val key1 = TranslationKey.key1[String]("tr1")
   val key2 = TranslationKey.key2[Int, Double]("tr2")
   val key3 = TranslationKey.key1[Double]("tr3")
@@ -37,31 +40,37 @@ class BindingsTest extends AsyncUdashFrontendTest {
         implicit val lang = Lang("en")
         div(
           "Translation: ",
+          translated(key0()),
+          translated(key0(), rawHtml = true),
           translated(key1("test")),
           translated(key2(3, 3.14)),
           translated(key3(0.99)),
           translated(key4("test", 1, true, 3.1415)),
-          translated(keyX("test", 1, true, 3.1415, "Udash".asInstanceOf[Any]))
+          translated(keyX("test", 1, true, 3.1415, "Udash".asInstanceOf[Any]), rawHtml = true)
         ).render
       }
       val template2 = {
         implicit val lang = Lang("pl")
         div(
           "Translation: ",
+          translated(key0()),
+          translated(key0(), rawHtml = true),
           translated(key1("test")),
           translated(key2(3, 3.14)),
           translated(key3(0.99)),
           translated(key4("test", 1, true, 3.1415)),
-          translated(keyX("test", 1.asInstanceOf[Any], true, 3.1415, "Udash"))
+          translated(keyX("test", 1.asInstanceOf[Any], true, 3.1415, "Udash"), rawHtml = true)
         ).render
       }
 
       for {
         _ <- retrying {
-          template.textContent should be("Translation: Translation testTranslation2 3.14 3Translation3 0.99Translation4 1 true 3.1415Translation5 Udash")
+          template.innerHTML should be("Translation: Translation testTranslation2 3.14 3Translation3 0.99Translation4 &lt;b&gt;1&lt;/b&gt; true 3.1415Translation5 <b>Udash</b>")
+          template.textContent should be("Translation: Translation testTranslation2 3.14 3Translation3 0.99Translation4 <b>1</b> true 3.1415Translation5 Udash")
         }
         r <- retrying {
-          template2.textContent should be("Translation: Translation test plTranslation2 3.14 3 plTranslation3 0.99 plTranslation4 1 true 3.1415 plTranslation5 Udash pl")
+          template2.innerHTML should be("Translation: Translation test plTranslation2 3.14 3 plTranslation3 0.99 plTranslation4 &lt;b&gt;1&lt;/b&gt; true 3.1415 plTranslation5 <b>Udash</b> pl")
+          template2.textContent should be("Translation: Translation test plTranslation2 3.14 3 plTranslation3 0.99 plTranslation4 <b>1</b> true 3.1415 plTranslation5 Udash pl")
         }
       } yield r
     }
@@ -143,37 +152,45 @@ class BindingsTest extends AsyncUdashFrontendTest {
         implicit val langProperty = en
         div(
           "Translation: ",
+          translatedDynamic(key0)(_()),
+          translatedDynamic(key0, rawHtml = true)(_()),
           translatedDynamic(key1)(key => key("test")),
           translatedDynamic(key2)(key => key(3, 3.14)),
           translatedDynamic(key3)(key => key(0.99)),
           translatedDynamic(key4)(key => key("test", 1, true, 3.1415)),
-          translatedDynamic(keyX)(key => key("test", 1, true, 3.1415, "Udash".asInstanceOf[Any]))
+          translatedDynamic(keyX, rawHtml = true)(key => key("test", 1, true, 3.1415, "Udash".asInstanceOf[Any]))
         ).render
       }
       val template2 = {
         implicit val langProperty = pl
         div(
           "Translation: ",
+          translatedDynamic(key0)(_()),
+          translatedDynamic(key0, rawHtml = true)(_()),
           translatedDynamic(key1)(key => key("test")),
           translatedDynamic(key2)(key => key(3, 3.14)),
           translatedDynamic(key3)(key => key(0.99)),
           translatedDynamic(key4)(key => key("test", 1, true, 3.1415)),
-          translatedDynamic(keyX)(key => key("test", 1.asInstanceOf[Any], true, 3.1415, "Udash"))
+          translatedDynamic(keyX, rawHtml = true)(key => key("test", 1.asInstanceOf[Any], true, 3.1415, "Udash"))
         ).render
       }
 
       for {
         _ <- retrying {
-          template.textContent should be("Translation: Translation testTranslation2 3.14 3Translation3 0.99Translation4 1 true 3.1415Translation5 Udash")
-          template2.textContent should be("Translation: Translation test plTranslation2 3.14 3 plTranslation3 0.99 plTranslation4 1 true 3.1415 plTranslation5 Udash pl")
+          template.innerHTML should be("Translation: Translation testTranslation2 3.14 3Translation3 0.99Translation4 &lt;b&gt;1&lt;/b&gt; true 3.1415Translation5 <b>Udash</b>")
+          template.textContent should be("Translation: Translation testTranslation2 3.14 3Translation3 0.99Translation4 <b>1</b> true 3.1415Translation5 Udash")
+          template2.innerHTML should be("Translation: Translation test plTranslation2 3.14 3 plTranslation3 0.99 plTranslation4 &lt;b&gt;1&lt;/b&gt; true 3.1415 plTranslation5 <b>Udash</b> pl")
+          template2.textContent should be("Translation: Translation test plTranslation2 3.14 3 plTranslation3 0.99 plTranslation4 <b>1</b> true 3.1415 plTranslation5 Udash pl")
         }
         _ <- Future {
           en.set(Lang("pl"))
           pl.set(Lang("en"))
         }
         r <- retrying {
-          template.textContent should be("Translation: Translation test plTranslation2 3.14 3 plTranslation3 0.99 plTranslation4 1 true 3.1415 plTranslation5 Udash pl")
-          template2.textContent should be("Translation: Translation testTranslation2 3.14 3Translation3 0.99Translation4 1 true 3.1415Translation5 Udash")
+          template.innerHTML should be("Translation: Translation test plTranslation2 3.14 3 plTranslation3 0.99 plTranslation4 &lt;b&gt;1&lt;/b&gt; true 3.1415 plTranslation5 <b>Udash</b> pl")
+          template.textContent should be("Translation: Translation test plTranslation2 3.14 3 plTranslation3 0.99 plTranslation4 <b>1</b> true 3.1415 plTranslation5 Udash pl")
+          template2.innerHTML should be("Translation: Translation testTranslation2 3.14 3Translation3 0.99Translation4 &lt;b&gt;1&lt;/b&gt; true 3.1415Translation5 <b>Udash</b>")
+          template2.textContent should be("Translation: Translation testTranslation2 3.14 3Translation3 0.99Translation4 <b>1</b> true 3.1415Translation5 Udash")
         }
       } yield r
     }


### PR DESCRIPTION
Right now translation ignore all HTML tags and insert them as text and make something like: `some <b>bold</b> text` is very tricky: you should concat it inside view.

This commit introduces a native support for this sort of string.