### PR TITLE
Callback sequencer revamp

### DIFF
--- a/core/.js/src/main/scala/io/udash/bindings/inputs/RangeInput.scala
+++ b/core/.js/src/main/scala/io/udash/bindings/inputs/RangeInput.scala
@@ -38,7 +38,7 @@ object RangeInput {
       propertyListeners += valueStep.listen({ v =>
         (step := v).applyTo(element)
         property.set(element.valueAsNumber)
-      }, true)
+      }, initUpdate = true)
 
       override def render: JSInput = element
     }

--- a/core/.js/src/main/scala/io/udash/bindings/inputs/RangeInput.scala
+++ b/core/.js/src/main/scala/io/udash/bindings/inputs/RangeInput.scala
@@ -27,18 +27,18 @@ object RangeInput {
 
       element.onchange = (_: Event) => property.set(element.valueAsNumber)
       propertyListeners += property.listen(element.valueAsNumber = _, initUpdate = true)
-      propertyListeners += minValue.listen { v =>
+      propertyListeners += minValue.listen({ v =>
         (min := v).applyTo(element)
         property.set(element.valueAsNumber)
-      }
-      propertyListeners += maxValue.listen { v =>
+      }, initUpdate = true)
+      propertyListeners += maxValue.listen({ v =>
         (max := v).applyTo(element)
         property.set(element.valueAsNumber)
-      }
-      propertyListeners += valueStep.listen { v =>
+      }, initUpdate = true)
+      propertyListeners += valueStep.listen({ v =>
         (step := v).applyTo(element)
         property.set(element.valueAsNumber)
-      }
+      }, true)
 
       override def render: JSInput = element
     }

--- a/core/.js/src/main/scala/io/udash/bindings/inputs/RangeInput.scala
+++ b/core/.js/src/main/scala/io/udash/bindings/inputs/RangeInput.scala
@@ -23,18 +23,22 @@ object RangeInput {
     valueStep: ReadableProperty[Double] = 1d.toProperty
   )(inputModifiers: Modifier*): InputBinding[JSInput] =
     new InputBinding[JSInput] {
-      private val element = input(
-        inputModifiers, tpe := "range",
-        nestedInterceptor(min.bind(minValue.transform(_.toString))),
-        nestedInterceptor(max.bind(maxValue.transform(_.toString))),
-        nestedInterceptor(step.bind(valueStep.transform(_.toString)))
-      ).render
+      private val element = input(inputModifiers, tpe := "range").render
 
       element.onchange = (_: Event) => property.set(element.valueAsNumber)
       propertyListeners += property.listen(element.valueAsNumber = _, initUpdate = true)
-      propertyListeners += minValue.listen(_ => property.set(element.valueAsNumber))
-      propertyListeners += maxValue.listen(_ => property.set(element.valueAsNumber))
-      propertyListeners += valueStep.listen(_ => property.set(element.valueAsNumber))
+      propertyListeners += minValue.listen { v =>
+        (min := v).applyTo(element)
+        property.set(element.valueAsNumber)
+      }
+      propertyListeners += maxValue.listen { v =>
+        (max := v).applyTo(element)
+        property.set(element.valueAsNumber)
+      }
+      propertyListeners += valueStep.listen { v =>
+        (step := v).applyTo(element)
+        property.set(element.valueAsNumber)
+      }
 
       override def render: JSInput = element
     }

--- a/core/src/main/scala/io/udash/properties/CallbackSequencer.scala
+++ b/core/src/main/scala/io/udash/properties/CallbackSequencer.scala
@@ -1,22 +1,20 @@
 package io.udash.properties
 
-import io.udash.utils.CrossCollections
-
 import scala.collection.mutable
 
 /**
  * <b>Note: It can be used only in one-thread environment!</b>
-  *
+ *
  * This sequencer is used in order to fire callback listeners ONCE during making many updates to [[io.udash.properties.single.Property]].
  * Property implementation uses this CallbackSequencer in order to queue callbacks and invoke them after
  * running commit().
  * In code you should use sequence method to group operation over the Property.
  */
-class CallbackSequencer {
+final class CallbackSequencer {
   type Id = String
 
   private var starts: Int = 0
-  private val queue: mutable.Buffer[(Id, () => Any)] = CrossCollections.createArray
+  private val queue: mutable.LinkedHashMap[Id, () => Any] = mutable.LinkedHashMap.empty
 
   private def start(): Unit =
     starts += 1
@@ -25,18 +23,18 @@ class CallbackSequencer {
     starts -= 1
   }
 
-  private def commit(): Boolean = {
+  private def commit(): Unit = {
     if (starts == 1) {
       val used = mutable.HashSet[Id]()
-      val waiting = queue.reverseIterator.collect {
-        case (id, callback) if !used.contains(id) =>
-          used += id
-          callback
-      }.toSeq.reverseIterator
-      queue.clear()
-      waiting.foreach(c => c())
-      used.nonEmpty
-    } else false
+      while (queue.nonEmpty) {
+        queue.retain { case (id, callback) =>
+          if (used.add(id)) {
+            callback()
+          }
+          false //removes
+        }
+      }
+    }
   }
 
   def queue(id: Id, fireListeners: () => Any): Unit = {
@@ -48,7 +46,7 @@ class CallbackSequencer {
     start()
     try {
       code
-      while (commit()) {}
+      commit()
     } finally {
       end()
     }

--- a/core/src/main/scala/io/udash/properties/CallbackSequencer.scala
+++ b/core/src/main/scala/io/udash/properties/CallbackSequencer.scala
@@ -38,8 +38,7 @@ final class CallbackSequencer {
   }
 
   def queue(id: Id, fireListeners: () => Any): Unit = {
-    if (starts == 0) fireListeners()
-    else queue += Tuple2(id, fireListeners)
+    sequence(queue += Tuple2(id, fireListeners))
   }
 
   def sequence(code: => Any): Unit = {

--- a/core/src/test/scala/io/udash/properties/CallbackSequencerTest.scala
+++ b/core/src/test/scala/io/udash/properties/CallbackSequencerTest.scala
@@ -109,26 +109,31 @@ class CallbackSequencerTest extends UdashCoreTest {
     "fire listeners queued by listeners" in {
       val fires = mutable.ArrayBuffer[String]()
       val l1 = () => fires += "a"
-      val l2 = () => CallbackSequencer().queue("2", () => fires += "b")
+      val l2a = () => CallbackSequencer().queue("2a", () => fires += "b")
       val l3 = () => fires += "c"
+      val lz = () => CallbackSequencer().queue("z", () => fires += "z")
 
       fires shouldBe empty
 
       CallbackSequencer().queue("1", l1)
       fires should contain theSameElementsInOrderAs Seq("a")
 
-      CallbackSequencer().queue("2", l2)
+      CallbackSequencer().queue("2", l2a)
       fires should contain theSameElementsInOrderAs Seq("a", "b")
 
       CallbackSequencer().queue("3", l3)
       fires should contain theSameElementsInOrderAs Seq("a", "b", "c")
+
+      CallbackSequencer().queue("z", lz) //same id won't be triggered again
+      fires should contain theSameElementsInOrderAs Seq("a", "b", "c")
     }
 
-    "fire listeners queued by sequenced listeners" ignore {
+    "fire listeners queued by sequenced listeners" in {
       val fires = mutable.ArrayBuffer[String]()
       val l1 = () => fires += "a"
-      val l2 = () => CallbackSequencer().queue("2", () => fires += "b")
+      val l2a = () => CallbackSequencer().queue("2a", () => fires += "b")
       val l3 = () => fires += "c"
+      val lz = () => CallbackSequencer().queue("z", () => fires += "z")
 
       fires shouldBe empty
 
@@ -136,10 +141,13 @@ class CallbackSequencerTest extends UdashCoreTest {
         CallbackSequencer().queue("1", l1)
         fires shouldBe empty
 
-        CallbackSequencer().queue("2", l2)
+        CallbackSequencer().queue("2", l2a)
         fires shouldBe empty
 
         CallbackSequencer().queue("3", l3)
+        fires shouldBe empty
+
+        CallbackSequencer().queue("z", lz)
         fires shouldBe empty
       }
 

--- a/core/src/test/scala/io/udash/properties/CallbackSequencerTest.scala
+++ b/core/src/test/scala/io/udash/properties/CallbackSequencerTest.scala
@@ -124,7 +124,7 @@ class CallbackSequencerTest extends UdashCoreTest {
       fires should contain theSameElementsInOrderAs Seq("a", "b", "c")
     }
 
-    "fire listeners queued by sequenced listeners" in {
+    "fire listeners queued by sequenced listeners" ignore {
       val fires = mutable.ArrayBuffer[String]()
       val l1 = () => fires += "a"
       val l2 = () => CallbackSequencer().queue("2", () => fires += "b")

--- a/core/src/test/scala/io/udash/properties/PropertyTest.scala
+++ b/core/src/test/scala/io/udash/properties/PropertyTest.scala
@@ -1127,67 +1127,92 @@ class PropertyTest extends UdashCoreTest {
 
     "synchronize values with another property" in {
       val source = Property(1)
-      val target = Property(5)
+      var sourceListener = 0
+      source.listen(sourceListener = _, initUpdate = true)
 
-      source.get should be(1)
-      target.get should be(5)
+      val target = Property(5)
+      var targetListener = 0
+      target.listen(targetListener = _, initUpdate = true)
+
+      source.get shouldBe 1
+      sourceListener shouldBe 1
+      target.get shouldBe 5
+      targetListener shouldBe 5
 
       //Init update
       val registration = source.sync(target)((i: Int) => i * 2, (i: Int) => i / 2)
 
-      registration.isActive should be(true)
-      source.get should be(1)
-      target.get should be(2)
+      registration.isActive shouldBe true
+      source.get shouldBe 1
+      sourceListener shouldBe 1
+      target.get shouldBe 2
+      targetListener shouldBe 2
 
       // Source update
       source.set(2)
 
-      source.get should be(2)
-      target.get should be(4)
+      source.get shouldBe 2
+      sourceListener shouldBe 2
+      target.get shouldBe 4
+      targetListener shouldBe 4
 
       // Source touch
       source.touch()
 
-      source.get should be(2)
-      target.get should be(4)
+      source.get shouldBe 2
+      sourceListener shouldBe 2
+      target.get shouldBe 4
+      targetListener shouldBe 4
 
       // Target update
       target.set(8)
 
-      source.get should be(4)
-      target.get should be(8)
+      source.get shouldBe 4
+      sourceListener shouldBe 4
+      target.get shouldBe 8
+      targetListener shouldBe 8
 
       // Source update
       source.set(2)
 
-      source.get should be(2)
-      target.get should be(4)
+      source.get shouldBe 2
+      sourceListener shouldBe 2
+      target.get shouldBe 4
+      targetListener shouldBe 4
 
       // Registration cancel and source update
       registration.cancel()
       source.set(1)
 
-      registration.isActive should be(false)
-      source.get should be(1)
-      target.get should be(4)
+      registration.isActive shouldBe false
+      source.get shouldBe 1
+      sourceListener shouldBe 1
+      target.get shouldBe 4
+      targetListener shouldBe 4
 
       // Target update
       target.set(1)
 
-      source.get should be(1)
-      target.get should be(1)
+      source.get shouldBe 1
+      sourceListener shouldBe 1
+      target.get shouldBe 1
+      targetListener shouldBe 1
 
       // Restart streaming, source touch
       registration.restart()
 
-      source.get should be(1)
-      target.get should be(2)
+      source.get shouldBe 1
+      sourceListener shouldBe 1
+      target.get shouldBe 2
+      targetListener shouldBe 2
 
       // Target update
       target.set(8)
 
-      source.get should be(4)
-      target.get should be(8)
+      source.get shouldBe 4
+      sourceListener shouldBe 4
+      target.get shouldBe 8
+      targetListener shouldBe 8
     }
 
     "synchronize values with SeqProperty" in {

--- a/core/src/test/scala/io/udash/properties/PropertyTest.scala
+++ b/core/src/test/scala/io/udash/properties/PropertyTest.scala
@@ -560,6 +560,28 @@ class PropertyTest extends UdashCoreTest {
       sqc.get should be(Seq(10, 5))
     }
 
+    "trigger once for multiply combined properties" in {
+      val calls = mutable.Buffer.empty[(Int, Int, Int)]
+
+      val p0 = Property.blank[Int]
+      val p1 = Property.blank[Int]
+      val p2 = Property.blank[Int]
+
+      p0.combine(p1)((_, _))
+        .combine(p2)((_, _))
+        .listen { case ((i1, i2), i3) =>
+          calls.append((i1, i2, i3))
+        }
+
+      CallbackSequencer().sequence {
+        p0.set(0)
+        p1.set(1)
+        p2.set(2)
+      }
+
+      calls should contain inOrderElementsOf Seq((0, 1, 2))
+    }
+
     "transform to ReadableSeqProperty" in {
       val elemListeners = mutable.Map.empty[PropertyId, Registration]
       var elementsUpdated = 0

--- a/core/src/test/scala/io/udash/properties/PropertyTest.scala
+++ b/core/src/test/scala/io/udash/properties/PropertyTest.scala
@@ -582,6 +582,19 @@ class PropertyTest extends UdashCoreTest {
       calls should contain inOrderElementsOf Seq((0, 1, 2))
     }
 
+    "short-circuit loops on self" in {
+      val p0 = Property.blank[Int]
+      p0.listen { v => if (v < 5) p0.set(v + 1) }
+
+      p0.set(1)
+
+      p0.get shouldBe 2
+
+      CallbackSequencer().sequence(p0.set(3))
+
+      p0.get shouldBe 4
+    }
+
     "transform to ReadableSeqProperty" in {
       val elemListeners = mutable.Map.empty[PropertyId, Registration]
       var elementsUpdated = 0

--- a/core/src/test/scala/io/udash/properties/PropertyTest.scala
+++ b/core/src/test/scala/io/udash/properties/PropertyTest.scala
@@ -584,7 +584,7 @@ class PropertyTest extends UdashCoreTest {
 
     "short-circuit loops on self" in {
       val p0 = Property.blank[Int]
-      p0.listen { v => if (v < 5) p0.set(v + 1) }
+      p0.listen { v => if (v < 10) p0.set(v + 1) }
 
       p0.set(1)
 

--- a/core/src/test/scala/io/udash/properties/PropertyTest.scala
+++ b/core/src/test/scala/io/udash/properties/PropertyTest.scala
@@ -563,9 +563,9 @@ class PropertyTest extends UdashCoreTest {
     "trigger once for multiply combined properties" in {
       val calls = mutable.Buffer.empty[(Int, Int, Int)]
 
-      val p0 = Property.blank[Int]
-      val p1 = Property.blank[Int]
-      val p2 = Property.blank[Int]
+      val p0 = Property(-1)
+      val p1 = Property(-1)
+      val p2 = Property(-1)
 
       p0.combine(p1)((_, _))
         .combine(p2)((_, _))
@@ -580,6 +580,16 @@ class PropertyTest extends UdashCoreTest {
       }
 
       calls should contain inOrderElementsOf Seq((0, 1, 2))
+
+      calls.clear()
+
+      CallbackSequencer().sequence {
+        p2.set(3)
+        p1.set(4)
+        p0.set(5)
+      }
+
+      calls should contain inOrderElementsOf Seq((5, 4, 3))
     }
 
     "short-circuit loops on self" in {


### PR DESCRIPTION
Changed introduced due to multiply combined properties firing twice with the same value (see tests). Also makes `.queue` have single semantics regardless of sequencer state.