### PR TITLE
Fixed inifinite loop in packageDoc 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -118,7 +118,7 @@ val testInBrowser = Seq(
 
 val noPublishSettings = Seq(
   publish / skip := true,
-  Compile / doc / sources := Seq.empty,
+  Compile / packageDoc / mappings := Seq.empty,
 )
 
 val aggregateProjectSettings = noPublishSettings ++ Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -118,7 +118,7 @@ val testInBrowser = Seq(
 
 val noPublishSettings = Seq(
   publish / skip := true,
-  Compile / doc := (doc / target).value,
+  Compile / doc / sources := Seq.empty,
 )
 
 val aggregateProjectSettings = noPublishSettings ++ Seq(


### PR DESCRIPTION
Previous setting in `noPublishSettings` :
```
Compile / doc := (doc / target).value
```
Caused an infinite loop when running `packageDoc` (or any task dependent on `packageDoc`) the second time, without removing the old doc.

Steps to reproduce:
```sh
sbt benchmarks/packageDoc #ok
sbt benchmarks/packageDoc #stuck on benchmarks / Compile / packageDoc
sbt benchmarks/clean
sbt benchmarks/packageDoc #ok again
```