### PR TITLE
Separate DatePicker initialization from options propagation

### DIFF
--- a/bootstrap4/.js/src/main/scala/io/udash/bootstrap/datepicker/UdashDatePicker.scala
+++ b/bootstrap4/.js/src/main/scala/io/udash/bootstrap/datepicker/UdashDatePicker.scala
@@ -553,7 +553,7 @@ object UdashDatePicker {
       val addedNodes = records.flatMap(record => for {i <- 0 until record.addedNodes.length} yield record.addedNodes(i))
       datePickerSetupCallbacks.foreach { case (pickerId, callback) =>
         if (addedNodes.exists {
-          case element: Element => element.querySelector(s"#$pickerId") != null
+          case element: Element => element.id == pickerId.id || element.querySelector(s"#$pickerId") != null
           case _ => false
         }) callback()
       }

--- a/bootstrap4/.js/src/main/scala/io/udash/bootstrap/datepicker/UdashDatePicker.scala
+++ b/bootstrap4/.js/src/main/scala/io/udash/bootstrap/datepicker/UdashDatePicker.scala
@@ -39,10 +39,13 @@ final class UdashDatePicker private[datepicker](
 
   locally {
     registerSetupCallback(componentId, () => {
-      jQInput.datetimepicker(
-        optionsToJsDict(options.get)
-          .setup(optionsDict => date.get.foreach(date => optionsDict.update("date", dateToMoment(date))))
-      )
+      // initialization
+      jQInput.datetimepicker()
+
+      // options propagation
+      optionsToJsDict(options.get)
+        .setup(optionsDict => date.get.foreach(date => optionsDict.update("date", dateToMoment(date))))
+        .foreach { case (optionKey, optionValue) => jQInput.datetimepicker(optionKey, optionValue) }
 
       nestedInterceptor(new JQueryOnBinding(jQInput, "change.datetimepicker", (_: Element, event: JQueryEvent) => {
         val dateOption = event.asInstanceOf[DatePickerChangeJQEvent].option
@@ -507,7 +510,7 @@ object UdashDatePicker {
 
   @js.native
   private trait UdashDatePickerJQuery extends JQuery {
-    def datetimepicker(settings: js.Dictionary[js.Any]): UdashDatePickerJQuery = js.native
+    def datetimepicker(): UdashDatePickerJQuery = js.native
     def datetimepicker(function: String): UdashDatePickerJQuery = js.native
     def datetimepicker(option: String, value: js.Any): UdashDatePickerJQuery = js.native
   }


### PR DESCRIPTION
When a TempusDominus DatePicker is embedded in a dynamic view (a popup/modal for instance), its options are not initialized properly when passed as a dictionary. The solution is to initialize the picker at first, and to set options sequentially then.

It should not affect picker's performance.

Might be related to #401.

More on options setup in [related docs](https://tempusdominus.github.io/bootstrap-4/Options/).