### PR TITLE
Use `jobs.exclude` key instead of `matrix.exclude`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 dist: trusty
 language: scala
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,12 +47,10 @@ env:
     - secure: fdBpnGod9OiHppoTk8v1uDnHcaG8vzZiORpqVLP0DWVvsdGxCfc2njUStxyD5LrNNTChd0W2aj9Ahchg88mlatheNvP/lnLpoU+1PIDNvshUmhOIVW1HDn4kkJQ783DW/Ch5fhRwupzr0LyW6BY+Ip+P2HIP3x/27ls8OUoX3Dr32BDPaRBQXl3RtFiic+pj1waB2qFK4Wbf4vWT0pSACaJXUGBWJq5LQ6QyTQ+pOcVBX65ZrsX5X6bSrgYapmkBgiNR/+cO7RIXeusHYmc6bchC8t6Rm/DfLosmR1iYMPGvVhTWaWo5t5x/xBAnEzBbKCHV7aE32OH69ed64/CcqtsgzPTT38Y5tvMCbDcUS3EJAqN1xEXdFcMWKkY4xzU2nekAIBdl9PT8Er2i/CCnMzG6/kxVCbnDD+Ujts+yJmWJPZ1dYdGkhhjqs9hpbden7UeAiRswVBt7fjB+crbpJxtLtWdRdwJnrbE7HnpTohG5/tfzZK98rSXou4KfigXmRneiObrp7n1OOOAiy/J70JxiT9hzMBEQVya2shx0v1TZgN39RrvYzN1fWdtvfrVke8XwQnjGxzgtOilQWqqUzBo+p7zx+Q+WALTPv/sU4//gmQFfIimf3b90KbcwzcCh3MwnTfANx0iScc9FktxfDozRvE3RTM/IHDKf9TJgaN8=
     - secure: JfVPHMqEITjrDqHbVkQZCR4VLtLUFchunlea7+JoIWpQ2o0RuSUA7jUk+bBG+Avj6qwYSu+1/wmTQY/xRQBTEDTiuf8CKROIX0sPeyTvTcGm31V0z+Ajxu7x4xmLH2hr4/9y35oAwqy0knBK84J3VZ6xGRKO3JQAnk/iotpb2uGj6wjso2rQnG56NNVuM/WIZ5BwRtJrCP7rbyOJTMMT639+ECrmppsEZnODqgARhe5PUT+DRn5MXvH0sayt38SukUkahD5qcnMthP3jbNkaMrZ0RlIAzbOQUvtzt1rwHjeo71V2Dd6q3kLworbkmbmmCbxd7DtWAmTcMir7+91hXLP6r+3q2YFh5juqXXFEDjox0Nqt1nl6sfHAJMEOIuji7XoJLSAK5nOY5OsFZ5WK/yF7JlllaBUFGIJOeQbf4k70Nr6nmer7iHrvaD3H2jhtkyp5cET/0hMNpo7jSnvoAk5l0eZhleWbTgwzbHpjjw/yDPKS+S+q+2DmtTrHcDa1Z79YHps/9hlryGM3kT3mCr2cwFP+aoPnXKGdPuiY95LcVPHeI8TKIopU3lOMXEPX1fTY/xNDauwl9zZfKm2dwJU9Qa3uF5NSgr0s0nzUuj4+VJlTr6tLREAEznPESTwmm9qlHrJPX4aXEDCxRdfgSRFsGoRTqkvoiwozdv8+Z1c=
 
-matrix:
+jobs:
   exclude:
     - scala: 2.11.12
       env: TEST_PACKAGE="guide-selenium/test"
-
-jobs:
   include:
     - stage: release
       scala: 2.12.10


### PR DESCRIPTION
It seems that using both `jobs.include` and `matrix.exclude` is no longer supported. Switching to `jobs.exclude` is oficially advised by [Travis docs](https://docs.travis-ci.com/user/build-matrix/#excluding-jobs).

Using both `jobs.include` and `matrix.exclude` causes build config validation errors (compare [Build#2837](https://travis-ci.org/UdashFramework/udash-core/builds/652022405/config) and [Build#2838](https://travis-ci.org/UdashFramework/udash-core/builds/652026911/config) configs), which, in turn, results in the [`release` stage suppression](https://travis-ci.org/UdashFramework/udash-core/builds/651881309).

Also, the `sudo: required` root option is now [deprecated](https://changelog.travis-ci.com/the-container-based-build-environment-is-fully-deprecated-84517).