### PR TITLE
Avoid linear list usages in routing

### DIFF
--- a/core/.js/src/main/scala/io/udash/routing/RoutingEngine.scala
+++ b/core/.js/src/main/scala/io/udash/routing/RoutingEngine.scala
@@ -76,7 +76,7 @@ class RoutingEngine[HierarchyRoot >: Null <: GState[HierarchyRoot] : PropertyCre
       currentState.parentState
     }
 
-    viewRenderer.renderView(viewsToLeave, viewsToAdd)
+    viewRenderer.renderView(viewsToLeave.iterator, viewsToAdd)
 
     if (fullReload || newState != oldState) callbacks.fire(StateChangeEvent(newState, oldState))
   }.recover { case ex: Throwable => statesMap.clear(); throw ex }

--- a/core/.js/src/main/scala/io/udash/routing/RoutingEngine.scala
+++ b/core/.js/src/main/scala/io/udash/routing/RoutingEngine.scala
@@ -49,7 +49,7 @@ class RoutingEngine[HierarchyRoot >: Null <: GState[HierarchyRoot] : PropertyCre
     val diffPath = findDiffSuffix(newStatePath.iterator, currentStatePath.iterator)
 
     val (viewsToLeave, viewsToAdd) = {
-      val toUpdateStatesSize = getUpdatablePathSize(diffPath, statesMap.keys.slice(samePath.size, statesMap.size).toList)
+      val toUpdateStatesSize = getUpdatablePathSize(diffPath.iterator, statesMap.keys.view(samePath.size, statesMap.size).iterator)
       val toRemoveStates = statesMap.slice(samePath.size + toUpdateStatesSize, statesMap.size)
       cleanup(toRemoveStates.values)
 
@@ -114,8 +114,8 @@ class RoutingEngine[HierarchyRoot >: Null <: GState[HierarchyRoot] : PropertyCre
     case None => acc
   }
 
-  private def getUpdatablePathSize(path: Iterable[HierarchyRoot], oldPath: Iterable[HierarchyRoot]): Int =
-    path.iterator.zip(oldPath.iterator).takeWhile {
+  private def getUpdatablePathSize(path: Iterator[HierarchyRoot], oldPath: Iterator[HierarchyRoot]): Int =
+    path.zip(oldPath).takeWhile {
       case (h1, h2) => viewFactoryRegistry.matchStateToResolver(h1) == viewFactoryRegistry.matchStateToResolver(h2)
     }.length
 

--- a/core/.js/src/main/scala/io/udash/routing/RoutingEngine.scala
+++ b/core/.js/src/main/scala/io/udash/routing/RoutingEngine.scala
@@ -63,7 +63,11 @@ class RoutingEngine[HierarchyRoot >: Null <: GState[HierarchyRoot] : PropertyCre
       statesMap ++= oldViewFactories
 
       val viewsToLeave = statesMap.values.map(_._1).iterator
-      val views = resolvePath(diffPath.view(toUpdateStatesSize, diffPath.size).iterator) //mutates statesMap
+      val views = diffPath.view(toUpdateStatesSize, diffPath.size).iterator.map { state =>
+        val (view, presenter) = viewFactoryRegistry.matchStateToResolver(state).create()
+        statesMap(state) = (view, presenter)
+        view
+      }.toList
       (viewsToLeave, views)
     }
 
@@ -124,11 +128,4 @@ class RoutingEngine[HierarchyRoot >: Null <: GState[HierarchyRoot] : PropertyCre
     }
   }
 
-  private def resolvePath(path: Iterator[HierarchyRoot]): List[View] = {
-    path.map { state =>
-      val (view, presenter) = viewFactoryRegistry.matchStateToResolver(state).create()
-      statesMap(state) = (view, presenter)
-      view
-    }.toList
-  }
 }

--- a/core/.js/src/main/scala/io/udash/routing/RoutingEngine.scala
+++ b/core/.js/src/main/scala/io/udash/routing/RoutingEngine.scala
@@ -10,7 +10,6 @@ import io.udash.utils.CallbacksHandler
 import io.udash.utils.FilteringUtils._
 
 import scala.annotation.tailrec
-import scala.scalajs.js
 
 final case class StateChangeEvent[S <: State](currentState: S, oldState: S) extends AbstractCase
 
@@ -46,14 +45,14 @@ class RoutingEngine[HierarchyRoot >: Null <: GState[HierarchyRoot] : PropertyCre
     val newStatePath = getStatePath(Some(newState))
 
     val samePathSize = findEqPrefix(newStatePath.iterator, statesMap.keysIterator).size
-    val diffPath = findDiffSuffix(newStatePath.iterator, statesMap.keysIterator).to[js.Array]
+    val diffPath = findDiffSuffix(newStatePath.iterator, statesMap.keysIterator).toSeq
 
     val (viewsToLeave, viewsToAdd) = {
       val toUpdateStatesSize = getUpdatablePathSize(diffPath.iterator, statesMap.slice(samePathSize, statesMap.size).keysIterator)
       cleanup(statesMap.slice(samePathSize + toUpdateStatesSize, statesMap.size).valuesIterator) //cleanup removed states
 
       val oldViewFactories =
-        newStatePath.view(samePathSize, samePathSize + toUpdateStatesSize).iterator
+        newStatePath.view.slice(samePathSize, samePathSize + toUpdateStatesSize).iterator
           .zip(statesMap.slice(samePathSize, samePathSize + toUpdateStatesSize).valuesIterator)
       var i = samePathSize
       statesMap.retain { (_, _) =>
@@ -63,7 +62,7 @@ class RoutingEngine[HierarchyRoot >: Null <: GState[HierarchyRoot] : PropertyCre
       statesMap ++= oldViewFactories
 
       val viewsToLeave = statesMap.values.map(_._1).iterator
-      val views = diffPath.view(toUpdateStatesSize, diffPath.size).iterator.map { state =>
+      val views = diffPath.view.slice(toUpdateStatesSize, diffPath.size).iterator.map { state =>
         val (view, presenter) = viewFactoryRegistry.matchStateToResolver(state).create()
         statesMap(state) = (view, presenter)
         view

--- a/core/.js/src/main/scala/io/udash/routing/RoutingEngine.scala
+++ b/core/.js/src/main/scala/io/udash/routing/RoutingEngine.scala
@@ -45,7 +45,7 @@ class RoutingEngine[HierarchyRoot >: Null <: GState[HierarchyRoot] : PropertyCre
     val currentStatePath = statesMap.keys.toList
     val newStatePath = getStatePath(Some(newState))
 
-    val samePath = findEqPrefix(newStatePath, currentStatePath)
+    val samePath = findEqPrefix(newStatePath.iterator, currentStatePath.iterator)
     val diffPath = findDiffSuffix(newStatePath.iterator, currentStatePath.iterator)
 
     val (viewsToLeave, viewsToAdd) = {

--- a/core/.js/src/main/scala/io/udash/routing/RoutingEngine.scala
+++ b/core/.js/src/main/scala/io/udash/routing/RoutingEngine.scala
@@ -46,7 +46,7 @@ class RoutingEngine[HierarchyRoot >: Null <: GState[HierarchyRoot] : PropertyCre
     val newStatePath = getStatePath(Some(newState))
 
     val samePath = findEqPrefix(newStatePath, currentStatePath)
-    val diffPath = findDiffSuffix(newStatePath, currentStatePath)
+    val diffPath = findDiffSuffix(newStatePath.iterator, currentStatePath.iterator)
 
     val (viewsToLeave, viewsToAdd) = {
       val toUpdateStatesSize = getUpdatablePathSize(diffPath, statesMap.keys.slice(samePath.size, statesMap.size).toList)

--- a/core/.js/src/main/scala/io/udash/view/ViewRenderer.scala
+++ b/core/.js/src/main/scala/io/udash/view/ViewRenderer.scala
@@ -68,7 +68,7 @@ private[udash] class ViewRenderer(rootElement: => Element) {
     * @param pathToAdd views list, which will be added to hierarchy
     */
   def renderView(subPathToLeave: List[View], pathToAdd: List[View]): Unit = {
-    val currentViewsToLeave = findEqPrefix(subPathToLeave, views.toList)
+    val currentViewsToLeave = findEqPrefix(subPathToLeave.iterator, views.iterator)
 
     if (currentViewsToLeave.isEmpty) {
       require(pathToAdd.nonEmpty, "You cannot remove all views, without adding any new view.")

--- a/core/.js/src/main/scala/io/udash/view/ViewRenderer.scala
+++ b/core/.js/src/main/scala/io/udash/view/ViewRenderer.scala
@@ -6,7 +6,6 @@ import io.udash.utils.FilteringUtils._
 import org.scalajs.dom.Element
 
 import scala.collection.mutable
-import scala.scalajs.js
 
 /**
   * ViewRenderer is used to provide mechanism to render nested [[View]] within provided [[rootElement]].
@@ -69,15 +68,15 @@ private[udash] class ViewRenderer(rootElement: => Element) {
    * @param pathToAdd      views list, which will be added to hierarchy
    */
   def renderView(subPathToLeave: Iterator[View], pathToAdd: Iterable[View]): Unit = {
-    val currentViewsToLeave = findEqPrefix(subPathToLeave, views.iterator).to[js.Array]
+    val currentViewsToLeaveSize = findEqPrefix(subPathToLeave, views.iterator).size
 
-    if (currentViewsToLeave.isEmpty) {
+    if (currentViewsToLeaveSize == 0) {
       require(pathToAdd.nonEmpty, "You cannot remove all views, without adding any new view.")
       replaceCurrentViews(pathToAdd)
     } else {
-      val removedViews = views.size - currentViewsToLeave.size
+      val removedViews = views.size - currentViewsToLeaveSize
       views.trimEnd(removedViews)
-      val rootView = currentViewsToLeave.last
+      val rootView = views.last
       val rootViewToAttach = mergeViews(pathToAdd.iterator)
       if (removedViews > 0 || rootViewToAttach.isDefined) {
         renderChild(rootView, rootViewToAttach)

--- a/core/.js/src/main/scala/io/udash/view/ViewRenderer.scala
+++ b/core/.js/src/main/scala/io/udash/view/ViewRenderer.scala
@@ -5,6 +5,7 @@ import io.udash.utils.FilteringUtils._
 import org.scalajs.dom.Element
 
 import scala.collection.mutable
+import scala.scalajs.js
 
 /**
   * ViewRenderer is used to provide mechanism to render nested [[View]] within provided [[rootElement]].
@@ -69,7 +70,7 @@ private[udash] class ViewRenderer(rootElement: => Element) {
    * @param pathToAdd      views list, which will be added to hierarchy
    */
   def renderView(subPathToLeave: Iterator[View], pathToAdd: Iterable[View]): Unit = {
-    val currentViewsToLeave = findEqPrefix(subPathToLeave, views.iterator)
+    val currentViewsToLeave = findEqPrefix(subPathToLeave, views.iterator).to[js.Array]
 
     if (currentViewsToLeave.isEmpty) {
       require(pathToAdd.nonEmpty, "You cannot remove all views, without adding any new view.")

--- a/core/.js/src/main/scala/io/udash/view/ViewRenderer.scala
+++ b/core/.js/src/main/scala/io/udash/view/ViewRenderer.scala
@@ -21,7 +21,8 @@ private[udash] class ViewRenderer(rootElement: => Element) {
         throw new RuntimeException(s"Only instances of ContainerView can render a child view! Check the states hierarchy of view $rest.")
     }
 
-  private def mergeViews(path: List[View]): Option[View] = {
+  private def mergeViews(path: Iterable[View]): Option[View] = {
+    //todo consider rewrite
     if (path.size == 1) {
       val singleView: View = path.head
       views.append(singleView)
@@ -37,7 +38,7 @@ private[udash] class ViewRenderer(rootElement: => Element) {
     }
   }
 
-  private def replaceCurrentViews(path: List[View]): Unit = {
+  private def replaceCurrentViews(path: Iterable[View]): Unit = {
     val rootView = mergeViews(path)
 
     views.clear()
@@ -57,18 +58,18 @@ private[udash] class ViewRenderer(rootElement: => Element) {
     * Current views: A -> B -> C -> D <br/>
     * subPathToLeave: A -> B <br/>
     * pathToAdd: E -> F <br/>
-    * <br/>
-    * Calls:<br/>
-    * A - nothing<br/>
-    * B - renderChild(E)<br/>
-    * E - getTemplate(); renderChild(F)<br/>
-    * F - getTemplate()<br/>
-    *
-    * @param subPathToLeave prefix of views hierarchy, which will not be removed
-    * @param pathToAdd views list, which will be added to hierarchy
-    */
-  def renderView(subPathToLeave: List[View], pathToAdd: List[View]): Unit = {
-    val currentViewsToLeave = findEqPrefix(subPathToLeave.iterator, views.iterator)
+   * <br/>
+   * Calls:<br/>
+   * A - nothing<br/>
+   * B - renderChild(E)<br/>
+   * E - getTemplate(); renderChild(F)<br/>
+   * F - getTemplate()<br/>
+   *
+   * @param subPathToLeave prefix of views hierarchy, which will not be removed
+   * @param pathToAdd      views list, which will be added to hierarchy
+   */
+  def renderView(subPathToLeave: Iterator[View], pathToAdd: Iterable[View]): Unit = {
+    val currentViewsToLeave = findEqPrefix(subPathToLeave, views.iterator)
 
     if (currentViewsToLeave.isEmpty) {
       require(pathToAdd.nonEmpty, "You cannot remove all views, without adding any new view.")

--- a/core/.js/src/main/scala/io/udash/view/ViewRenderer.scala
+++ b/core/.js/src/main/scala/io/udash/view/ViewRenderer.scala
@@ -8,8 +8,8 @@ import org.scalajs.dom.Element
 import scala.collection.mutable
 
 /**
-  * ViewRenderer is used to provide mechanism to render nested [[View]] within provided [[rootElement]].
-  */
+ * ViewRenderer is used to provide mechanism to render nested [[View]] within provided [[rootElement]].
+ */
 private[udash] class ViewRenderer(rootElement: => Element) {
   private lazy val endpoint = rootElement
   private val views = mutable.ArrayBuffer[View]()
@@ -23,18 +23,14 @@ private[udash] class ViewRenderer(rootElement: => Element) {
     }
 
   private def mergeViews(path: Iterator[View]): Option[View] = {
-    val result = path.nextOpt.toOption
-
-    result.foreach { top =>
+    path.nextOpt.setup(_.foreach { top =>
       val lastElement = path.fold(top) { case (parent, child) =>
         renderChild(parent, Some(child))
         views.append(parent)
         child
       }
       views.append(lastElement)
-    }
-
-    result
+    }).toOption
   }
 
   private def replaceCurrentViews(path: Iterable[View]): Unit = {
@@ -51,12 +47,12 @@ private[udash] class ViewRenderer(rootElement: => Element) {
   }
 
   /**
-    * Updates views hierarchy.
-    * <br/><br/>
-    * Example: <br/>
-    * Current views: A -> B -> C -> D <br/>
-    * subPathToLeave: A -> B <br/>
-    * pathToAdd: E -> F <br/>
+   * Updates views hierarchy.
+   * <br/><br/>
+   * Example: <br/>
+   * Current views: A -> B -> C -> D <br/>
+   * subPathToLeave: A -> B <br/>
+   * pathToAdd: E -> F <br/>
    * <br/>
    * Calls:<br/>
    * A - nothing<br/>

--- a/core/.js/src/test/scala/io/udash/testing/TestViewRenderer.scala
+++ b/core/.js/src/test/scala/io/udash/testing/TestViewRenderer.scala
@@ -1,20 +1,20 @@
 package io.udash.testing
 
+import com.avsystem.commons._
 import io.udash._
 
-import scala.collection.mutable
-
 class TestViewRenderer extends ViewRenderer(null) {
-  val views = mutable.ArrayBuffer[View]()
+  val views = MArrayBuffer[View]()
   var lastSubPathToLeave: List[View] = Nil
-  var lastPathToAdd: List[View] = Nil
+  var lastPathToAdd: Iterable[View] = Nil
 
-  override def renderView(subPathToLeave: List[View], pathToAdd: List[View]): Unit = {
+  override def renderView(subPathToLeave: Iterator[View], pathToAdd: Iterable[View]): Unit = {
+    val subPathList = subPathToLeave.toList
     views.clear()
-    views.appendAll(subPathToLeave)
+    views.appendAll(subPathList)
     views.appendAll(pathToAdd)
 
-    lastSubPathToLeave = subPathToLeave
+    lastSubPathToLeave = subPathList
     lastPathToAdd = pathToAdd
   }
 }

--- a/core/.js/src/test/scala/io/udash/view/ViewRendererTest.scala
+++ b/core/.js/src/test/scala/io/udash/view/ViewRendererTest.scala
@@ -12,7 +12,7 @@ class ViewRendererTest extends UdashFrontendTest {
       val childViewB = new TestView
       val childViewC = new TestView
 
-      renderer.renderView(Nil, rootView :: childViewA :: childViewB :: childViewC :: Nil)
+      renderer.renderView(Iterator.empty, rootView :: childViewA :: childViewB :: childViewC :: Nil)
 
       rootView.lastChild should be(childViewA)
       childViewA.lastChild should be(childViewB)
@@ -28,7 +28,7 @@ class ViewRendererTest extends UdashFrontendTest {
       val childViewB = new TestView
       val childViewC = new TestView
 
-      renderer.renderView(Nil, rootView :: childViewA :: childViewB :: childViewC :: Nil)
+      renderer.renderView(Iterator.empty, rootView :: childViewA :: childViewB :: childViewC :: Nil)
 
       rootView.lastChild should be(childViewA)
       childViewA.lastChild should be(childViewB)
@@ -43,7 +43,7 @@ class ViewRendererTest extends UdashFrontendTest {
       //clear last child
       Seq(rootView, childViewA, childViewB, childViewC).foreach(_.lastChild = null)
 
-      renderer.renderView(rootView :: childViewA :: Nil, childViewC :: childViewB :: Nil)
+      renderer.renderView(Iterator(rootView, childViewA), childViewC :: childViewB :: Nil)
 
       rootView.lastChild should be(null) // renderChild was not called
       childViewA.lastChild should be(childViewC)
@@ -64,7 +64,7 @@ class ViewRendererTest extends UdashFrontendTest {
       val childViewB = new TestView
       val childViewC = new TestView
 
-      renderer.renderView(Nil, rootView :: childViewA :: childViewB :: childViewC :: Nil)
+      renderer.renderView(Iterator.empty, rootView :: childViewA :: childViewB :: childViewC :: Nil)
 
       rootView.lastChild should be(childViewA)
       childViewA.lastChild should be(childViewB)
@@ -79,7 +79,7 @@ class ViewRendererTest extends UdashFrontendTest {
       //clear last child
       Seq(rootView, childViewA, childViewB, childViewC).foreach(_.lastChild = null)
 
-      renderer.renderView(rootView :: childViewB :: childViewA :: Nil, childViewC :: Nil)
+      renderer.renderView(Iterator(rootView, childViewB, childViewA), childViewC :: Nil)
 
       rootView.lastChild should be(childViewC)
       childViewA.lastChild should be(null)
@@ -100,7 +100,7 @@ class ViewRendererTest extends UdashFrontendTest {
       val childViewB = new TestView
       val childViewC = new TestView
 
-      renderer.renderView(Nil, rootView :: childViewA :: childViewB :: childViewC :: Nil)
+      renderer.renderView(Iterator.empty, rootView :: childViewA :: childViewB :: childViewC :: Nil)
 
       rootView.lastChild should be(childViewA)
       childViewA.lastChild should be(childViewB)
@@ -112,7 +112,7 @@ class ViewRendererTest extends UdashFrontendTest {
       childViewB.renderingCounter should be(1)
       childViewC.renderingCounter should be(1)
 
-      renderer.renderView(rootView :: childViewA :: Nil, Nil)
+      renderer.renderView(Iterator(rootView, childViewA), Nil)
 
       rootView.lastChild should be(childViewA)
       childViewA.lastChild should be(null)
@@ -131,8 +131,8 @@ class ViewRendererTest extends UdashFrontendTest {
       val childViewB = new TestView
       val childViewC = new TestView
 
-      renderer.renderView(Nil, rootView :: Nil)
-      renderer.renderView(rootView :: Nil, childViewA :: childViewB :: childViewC :: Nil)
+      renderer.renderView(Iterator.empty, rootView :: Nil)
+      renderer.renderView(Iterator(rootView), childViewA :: childViewB :: childViewC :: Nil)
 
       rootView.lastChild should be(childViewA)
       childViewA.lastChild should be(childViewB)
@@ -144,7 +144,7 @@ class ViewRendererTest extends UdashFrontendTest {
       childViewB.renderingCounter should be(1)
       childViewC.renderingCounter should be(1)
 
-      renderer.renderView(rootView :: childViewA :: childViewB :: childViewC :: Nil, Nil)
+      renderer.renderView(Iterator(rootView, childViewA, childViewB, childViewC), Nil)
 
       rootView.lastChild should be(childViewA)
       childViewA.lastChild should be(childViewB)
@@ -165,8 +165,8 @@ class ViewRendererTest extends UdashFrontendTest {
       val childViewB = new TestView
       val childViewC = new TestFinalView
 
-      renderer.renderView(Nil, rootView :: Nil)
-      renderer.renderView(rootView :: Nil, childViewA :: childViewB :: childViewC :: Nil)
+      renderer.renderView(Iterator.empty, rootView :: Nil)
+      renderer.renderView(Iterator(rootView), childViewA :: childViewB :: childViewC :: Nil)
 
       rootView.lastChild should be(childViewA)
       childViewA.lastChild should be(childViewB)
@@ -177,7 +177,7 @@ class ViewRendererTest extends UdashFrontendTest {
       childViewB.renderingCounter should be(1)
       childViewC.renderingCounter should be(1)
 
-      renderer.renderView(rootView :: childViewA :: childViewB :: childViewC :: Nil, Nil)
+      renderer.renderView(Iterator(rootView, childViewA, childViewB, childViewC), Nil)
 
       rootView.lastChild should be(childViewA)
       childViewA.lastChild should be(childViewB)
@@ -188,7 +188,7 @@ class ViewRendererTest extends UdashFrontendTest {
       childViewB.renderingCounter should be(1)
       childViewC.renderingCounter should be(1)
 
-      renderer.renderView(rootView :: childViewA :: childViewB :: Nil, Nil)
+      renderer.renderView(Iterator(rootView, childViewA, childViewB), Nil)
 
       rootView.lastChild should be(childViewA)
       childViewA.lastChild should be(childViewB)
@@ -199,7 +199,7 @@ class ViewRendererTest extends UdashFrontendTest {
       childViewB.renderingCounter should be(1)
       childViewC.renderingCounter should be(1)
 
-      renderer.renderView(rootView :: childViewA :: childViewB :: Nil, childViewC :: Nil)
+      renderer.renderView(Iterator(rootView, childViewA, childViewB), childViewC :: Nil)
 
       rootView.lastChild should be(childViewA)
       childViewA.lastChild should be(childViewB)

--- a/utils/.js/src/main/scala/io/udash/utils/CrossCollections.scala
+++ b/utils/.js/src/main/scala/io/udash/utils/CrossCollections.scala
@@ -5,8 +5,8 @@ import com.avsystem.commons._
 
 import scala.scalajs.js
 
-private[udash]
-object CrossCollections {
+private[udash] object CrossCollections {
+
   import scala.scalajs.js.JSConverters._
 
   def toCrossArray[T](t: Iterable[T]): MBuffer[T] = t.toJSArray

--- a/utils/.jvm/src/main/scala/io/udash/utils/CrossCollections.scala
+++ b/utils/.jvm/src/main/scala/io/udash/utils/CrossCollections.scala
@@ -2,10 +2,10 @@ package io.udash
 package utils
 
 import com.avsystem.commons._
+
 import scala.collection.compat._
 
-private[udash]
-object CrossCollections {
+private[udash] object CrossCollections {
   def toCrossArray[T](t: Iterable[T]): MBuffer[T] = t.to(MArrayBuffer)
   def createArray[T]: MBuffer[T] = new MArrayBuffer[T]
   def createDictionary[T]: MMap[String, T] = new MHashMap[String, T]

--- a/utils/src/main/scala/io/udash/utils/FilteringUtils.scala
+++ b/utils/src/main/scala/io/udash/utils/FilteringUtils.scala
@@ -4,12 +4,12 @@ import com.avsystem.commons._
 
 object FilteringUtils {
   /** Finds the longest lists prefix with equal elements. */
-  def findEqPrefix[T](newPath: Iterator[T], previousPath: Iterator[T]): List[T] =
-    newPath.zip(previousPath).takeWhile { case (h1, h2) => h1 == h2 }.map(_._1).toList
+  def findEqPrefix[T](newPath: Iterator[T], previousPath: Iterator[T]): Iterator[T] =
+    newPath.zip(previousPath).takeWhile { case (h1, h2) => h1 == h2 }.map(_._1)
 
   /** Finds @newPath suffix which is different than in @previousPath. */
-  def findDiffSuffix[T](newPath: Iterator[T], previousPath: Iterator[T]): List[T] =
+  def findDiffSuffix[T](newPath: Iterator[T], previousPath: Iterator[T]): Iterator[T] =
     newPath.map(_.opt).zipAll(previousPath.map(_.opt), Opt.Empty, Opt.Empty).dropWhile { case (h1, h2) =>
       h1 == h2
-    }.flatMap(_._1).toList
+    }.flatMap(_._1)
 }

--- a/utils/src/main/scala/io/udash/utils/FilteringUtils.scala
+++ b/utils/src/main/scala/io/udash/utils/FilteringUtils.scala
@@ -2,26 +2,14 @@ package io.udash.utils
 
 import com.avsystem.commons._
 
-import scala.annotation.tailrec
-
 object FilteringUtils {
   /** Finds the longest lists prefix with equal elements. */
-  def findEqPrefix[T](newPath: List[T], previousPath: List[T]): List[T] = {
-    @tailrec
-    def _findEqPrefix(newPath: List[T], previousPath: List[T], subPath: List[T]): List[T] = {
-      (newPath, previousPath) match {
-        case (head1 :: tail1, head2 :: tail2) if head1 == head2 => _findEqPrefix(tail1, tail2, subPath :+ head1)
-        case _ => subPath
-      }
-    }
-
-    _findEqPrefix(newPath, previousPath, Nil)
-  }
+  def findEqPrefix[T](newPath: Iterator[T], previousPath: Iterator[T]): List[T] =
+    newPath.zip(previousPath).takeWhile { case (h1, h2) => h1 == h2 }.map(_._1).toList
 
   /** Finds @newPath suffix which is different than in @previousPath. */
-  def findDiffSuffix[T](newPath: Iterator[T], previousPath: Iterator[T]): List[T] = {
+  def findDiffSuffix[T](newPath: Iterator[T], previousPath: Iterator[T]): List[T] =
     newPath.map(_.opt).zipAll(previousPath.map(_.opt), Opt.Empty, Opt.Empty).dropWhile { case (h1, h2) =>
       h1 == h2
     }.flatMap(_._1).toList
-  }
 }

--- a/utils/src/main/scala/io/udash/utils/FilteringUtils.scala
+++ b/utils/src/main/scala/io/udash/utils/FilteringUtils.scala
@@ -1,5 +1,7 @@
 package io.udash.utils
 
+import com.avsystem.commons._
+
 import scala.annotation.tailrec
 
 object FilteringUtils {
@@ -17,15 +19,9 @@ object FilteringUtils {
   }
 
   /** Finds @newPath suffix which is different than in @previousPath. */
-  def findDiffSuffix[T](newPath: List[T], previousPath: List[T]): List[T] = {
-    @tailrec
-    def _findDiffSuffix(newPath: List[T], previousPath: List[T], subPath: List[T]): List[T] = (newPath, previousPath) match {
-      case (head1 :: tail1, head2 :: tail2) if subPath == Nil && head1 == head2 => _findDiffSuffix(tail1, tail2, subPath)
-      case (head1 :: tail1, _ :: tail2) => _findDiffSuffix(tail1, tail2, subPath :+ head1)
-      case (head1 :: tail1, Nil) => _findDiffSuffix(tail1, Nil, subPath :+ head1)
-      case _ => subPath
-    }
-
-    _findDiffSuffix(newPath, previousPath, Nil)
+  def findDiffSuffix[T](newPath: Iterator[T], previousPath: Iterator[T]): List[T] = {
+    newPath.map(_.opt).zipAll(previousPath.map(_.opt), Opt.Empty, Opt.Empty).dropWhile { case (h1, h2) =>
+      h1 == h2
+    }.flatMap(_._1).toList
   }
 }

--- a/utils/src/main/scala/io/udash/utils/FilteringUtils.scala
+++ b/utils/src/main/scala/io/udash/utils/FilteringUtils.scala
@@ -3,7 +3,7 @@ package io.udash.utils
 import com.avsystem.commons._
 
 object FilteringUtils {
-  /** Finds the longest lists prefix with equal elements. */
+  /** Finds the longest prefix with equal elements. */
   def findEqPrefix[T](newPath: Iterator[T], previousPath: Iterator[T]): Iterator[T] =
     newPath.zip(previousPath).takeWhile { case (h1, h2) => h1 == h2 }.map(_._1)
 

--- a/utils/src/test/scala/io/udash/utils/FilteringUtilsTest.scala
+++ b/utils/src/test/scala/io/udash/utils/FilteringUtilsTest.scala
@@ -33,23 +33,23 @@ class FilteringUtilsTest extends UdashSharedTest {
       val a = 1 :: 2 :: 3 :: 4 :: 5 :: Nil
       val b = 1 :: 2 :: 3 :: 6 :: 5 :: Nil
 
-      findDiffSuffix(a, b) should be(4 :: 5 :: Nil)
-      findDiffSuffix(b, a) should be(6 :: 5 :: Nil)
+      findDiffSuffix(a.iterator, b.iterator).toList should be(4 :: 5 :: Nil)
+      findDiffSuffix(b.iterator, a.iterator).toList should be(6 :: 5 :: Nil)
 
       val c = 3 :: 2 :: 3 :: 4 :: 5 :: Nil
       val d = 1 :: 2 :: 3 :: 6 :: 5 :: Nil
 
-      findDiffSuffix(c, d) should be(3 :: 2 :: 3 :: 4 :: 5 :: Nil)
-      findDiffSuffix(d, c) should be(1 :: 2 :: 3 :: 6 :: 5 :: Nil)
+      findDiffSuffix(c.iterator, d.iterator).toList should be(3 :: 2 :: 3 :: 4 :: 5 :: Nil)
+      findDiffSuffix(d.iterator, c.iterator).toList should be(1 :: 2 :: 3 :: 6 :: 5 :: Nil)
 
       val e = Nil
       val f = 1 :: 2 :: 3 :: 6 :: 5 :: Nil
 
-      findDiffSuffix(e, f) should be(Nil)
-      findDiffSuffix(f, e) should be(1 :: 2 :: 3 :: 6 :: 5 :: Nil)
+      findDiffSuffix(e.iterator, f.iterator).toList should be(Nil)
+      findDiffSuffix(f.iterator, e.iterator).toList should be(1 :: 2 :: 3 :: 6 :: 5 :: Nil)
 
-      findDiffSuffix(e, e) should be(Nil)
-      findDiffSuffix(f, f) should be(Nil)
+      findDiffSuffix(e.iterator, e.iterator).toList should be(Nil)
+      findDiffSuffix(f.iterator, f.iterator).toList should be(Nil)
     }
   }
 }

--- a/utils/src/test/scala/io/udash/utils/FilteringUtilsTest.scala
+++ b/utils/src/test/scala/io/udash/utils/FilteringUtilsTest.scala
@@ -10,23 +10,23 @@ class FilteringUtilsTest extends UdashSharedTest {
       val a = 1 :: 2 :: 3 :: 4 :: 5 :: Nil
       val b = 1 :: 2 :: 3 :: 6 :: 5 :: Nil
 
-      findEqPrefix(a, b) should be(1 :: 2 :: 3 :: Nil)
-      findEqPrefix(b, a) should be(1 :: 2 :: 3 :: Nil)
+      findEqPrefix(a.iterator, b.iterator).toList should be(1 :: 2 :: 3 :: Nil)
+      findEqPrefix(b.iterator, a.iterator).toList should be(1 :: 2 :: 3 :: Nil)
 
       val c = 3 :: 2 :: 3 :: 4 :: 5 :: Nil
       val d = 1 :: 2 :: 3 :: 6 :: 5 :: Nil
 
-      findEqPrefix(c, d) should be(Nil)
-      findEqPrefix(d, c) should be(Nil)
+      findEqPrefix(c.iterator, d.iterator).toList should be(Nil)
+      findEqPrefix(d.iterator, c.iterator).toList should be(Nil)
 
       val e = Nil
       val f = 1 :: 2 :: 3 :: 6 :: 5 :: Nil
 
-      findEqPrefix(e, f) should be(Nil)
-      findEqPrefix(f, e) should be(Nil)
+      findEqPrefix(e.iterator, f.iterator).toList should be(Nil)
+      findEqPrefix(f.iterator, e.iterator).toList should be(Nil)
 
-      findEqPrefix(e, e) should be(Nil)
-      findEqPrefix(f, f) should be(f)
+      findEqPrefix(e.iterator, e.iterator).toList should be(Nil)
+      findEqPrefix(f.iterator, f.iterator).toList should be(f)
     }
 
     "find different suffix in lists" in {


### PR DESCRIPTION
* filtering utils appended to created lists
* `.last` calls etc.
* usage of iterators / indexes where possible