### PR TITLE
SttpRestClient request configuration

### DIFF
--- a/rest/src/main/scala/io/udash/rest/SttpRestClient.scala
+++ b/rest/src/main/scala/io/udash/rest/SttpRestClient.scala
@@ -13,7 +13,7 @@ import scala.concurrent.Future
 object SttpRestClient {
   def defaultBackend(): SttpBackend[Future, Nothing] = DefaultSttpBackend()
 
-  private final val defaultRequestOptions = RequestOptions(
+  final val defaultRequestOptions = RequestOptions(
     followRedirects = true,
     readTimeout = DefaultReadTimeout,
     maxRedirects = 32, //FollowRedirectsBackend.MaxRedirects

--- a/rest/src/main/scala/io/udash/rest/SttpRestClient.scala
+++ b/rest/src/main/scala/io/udash/rest/SttpRestClient.scala
@@ -13,7 +13,7 @@ import scala.concurrent.Future
 object SttpRestClient {
   def defaultBackend(): SttpBackend[Future, Nothing] = DefaultSttpBackend()
 
-  final val defaultRequestOptions = RequestOptions(
+  final val DefaultRequestOptions = RequestOptions(
     followRedirects = true,
     readTimeout = DefaultReadTimeout,
     maxRedirects = 32, //FollowRedirectsBackend.MaxRedirects
@@ -27,7 +27,7 @@ object SttpRestClient {
     */
   @explicitGenerics def apply[RestApi: RawRest.AsRealRpc : RestMetadata](
     baseUri: String,
-    options: RequestOptions = defaultRequestOptions
+    options: RequestOptions = DefaultRequestOptions
   )(implicit backend: SttpBackend[Future, Nothing]): RestApi =
     RawRest.fromHandleRequest[RestApi](asHandleRequest(baseUri, options))
 
@@ -35,7 +35,7 @@ object SttpRestClient {
     * Creates a [[io.udash.rest.raw.RawRest.HandleRequest HandleRequest]] function which sends REST requests to
     * a specified base URI using default HTTP client implementation (sttp).
     */
-  def asHandleRequest(baseUri: String, options: RequestOptions = defaultRequestOptions)(
+  def asHandleRequest(baseUri: String, options: RequestOptions = DefaultRequestOptions)(
     implicit backend: SttpBackend[Future, Nothing]
   ): RawRest.HandleRequest =
     asHandleRequest(uri"$baseUri", options)


### PR DESCRIPTION
Currently, method `toSttpRequest` in `SttpRestClient` creates `basicRequest.method` with default `RequestOptions` which hardcodes both `read`- and `requestTimeout` HTTP request parameters to 60 seconds. 
Exposed `RequestOptions` to the `SttpRestClient` constructor to enable request timeout configuration.