### PR TITLE
View rendering improvements

### DIFF
--- a/core/.js/src/main/scala/io/udash/core/Definitions.scala
+++ b/core/.js/src/main/scala/io/udash/core/Definitions.scala
@@ -74,11 +74,9 @@ trait ContainerView extends View {
   /** Default implementation renders child views inside this element. */
   protected val childViewContainer: Element = div().render
 
-  protected def clearChildViewContainer(): Unit = {
-    while (childViewContainer.childElementCount > 0) { //todo
+  protected def clearChildViewContainer(): Unit =
+    while (childViewContainer.firstChild != null)
       childViewContainer.removeChild(childViewContainer.firstChild)
-    }
-  }
 
   /**
    * Will be invoked by [[io.udash.routing.RoutingEngine]] in order to render the child view inside

--- a/core/.js/src/main/scala/io/udash/core/Definitions.scala
+++ b/core/.js/src/main/scala/io/udash/core/Definitions.scala
@@ -74,21 +74,31 @@ trait ContainerView extends View {
   /** Default implementation renders child views inside this element. */
   protected val childViewContainer: Element = div().render
 
-  /**
-    * Will be invoked by [[io.udash.routing.RoutingEngine]] in order to render the child view inside
-    * the parent view. <br/><br/>
-    *
-    * <b>This method can receive `None` as "view" argument, then previous child view should be removed.</b>
-    *
-    * The default implementation removes everything from `childViewContainer` and renders new subview inside.
-    *
-    * @param view view which origins from child
-    */
-  def renderChild(view: Option[View]): Unit = {
-    while (childViewContainer.childElementCount > 0) {
+  protected def clearChildViewContainer(): Unit = {
+    while (childViewContainer.childElementCount > 0) { //todo
       childViewContainer.removeChild(childViewContainer.firstChild)
     }
-    view.foreach(_.getTemplate.applyTo(childViewContainer))
+  }
+
+  /**
+   * Will be invoked by [[io.udash.routing.RoutingEngine]] in order to render the child view inside
+   * the parent view. <br/><br/>
+   *
+   * <b>This method can receive `None` as "view" argument, then previous child view should be removed.</b>
+   *
+   * The default implementation removes everything from `childViewContainer` and renders new subview inside.
+   *
+   * @param view view which origins from child
+    */
+  def renderChild(view: Option[View]): Unit = {
+    clearChildViewContainer()
+    view.foreach { view =>
+      view match {
+        case container: ContainerView => container.clearChildViewContainer()
+        case _ =>
+      }
+      view.getTemplate.applyTo(childViewContainer)
+    }
   }
 }
 

--- a/core/.js/src/test/scala/io/udash/ApplicationTest.scala
+++ b/core/.js/src/test/scala/io/udash/ApplicationTest.scala
@@ -5,7 +5,7 @@ import io.udash.testing._
 class ApplicationTest extends UdashFrontendTest with TestRouting {
 
   "Application" should {
-    initTestRouting()
+    initTestRouting(default = () => new TestViewFactory[TestState])
     val initUrl = Url("/")
     val urlProvider: TestUrlChangeProvider = new TestUrlChangeProvider(initUrl)
     val app = new Application[TestState](routing, vpRegistry, urlProvider)
@@ -16,7 +16,6 @@ class ApplicationTest extends UdashFrontendTest with TestRouting {
       urlProvider.changeListeners.size should be(1)
       routing.urlsHistory should contain(initUrl)
       vpRegistry.statesHistory should contain(RootState(None))
-      viewFactory.presenter.lastHandledState should be(RootState(None))
     }
 
     "change URL basing on state" in {

--- a/core/.js/src/test/scala/io/udash/routing/UrlLoggingTest.scala
+++ b/core/.js/src/test/scala/io/udash/routing/UrlLoggingTest.scala
@@ -10,7 +10,10 @@ class UrlLoggingTest extends AsyncUdashFrontendTest with TestRouting {
   "UrlLogging" should {
     "call logging impl on url change" in {
       val urlWithRef = ListBuffer.empty[(String, Option[String])]
-      initTestRouting()
+
+      new TestViewFactory[TestState]: ViewFactory[_ <: TestState]
+
+      initTestRouting(default = () => new TestViewFactory[TestState])
       val initUrl = Url("/")
       val urlProvider: TestUrlChangeProvider = new TestUrlChangeProvider(initUrl)
       val app = new Application[TestState](routing, vpRegistry, urlProvider) with UrlLogging[TestState] {

--- a/core/.js/src/test/scala/io/udash/testing/TestRouting.scala
+++ b/core/.js/src/test/scala/io/udash/testing/TestRouting.scala
@@ -12,11 +12,11 @@ trait TestRouting {
   private[udash] var routingEngine: RoutingEngine[TestState] = _
 
   protected final def initTestRouting(routing: TestRoutingRegistry = new TestRoutingRegistry,
-    state2vp: Map[TestState, () => ViewFactory[_ <: TestState]] = Map.empty
+    state2vp: Map[TestState, () => ViewFactory[_ <: TestState]] = Map.empty, default: () => ViewFactory[_ <: TestState] = () => viewFactory
   ): Unit = {
     this.routing = routing
     viewFactory = new TestViewFactory[ErrorState.type]
-    vpRegistry = new TestViewFactoryRegistry(state2vp, viewFactory)
+    vpRegistry = new TestViewFactoryRegistry(state2vp, default)
     renderer = new TestViewRenderer
   }
 

--- a/core/.js/src/test/scala/io/udash/testing/TestViewFactory.scala
+++ b/core/.js/src/test/scala/io/udash/testing/TestViewFactory.scala
@@ -1,6 +1,7 @@
 package io.udash.testing
 
 import io.udash._
+import org.scalajs.dom
 
 class TestViewFactory[T <: TestState] extends ViewFactory[T] {
   val view = new TestView
@@ -26,9 +27,12 @@ class TestView extends ContainerView {
 
   override def getTemplate: Modifier = {
     renderingCounter += 1
-    div(
-      toString,
-      childViewContainer
+    Seq[Modifier](
+      div(
+        toString,
+        childViewContainer
+      ),
+      dom.document.createTextNode(toString),
     )
   }
 

--- a/core/.js/src/test/scala/io/udash/testing/TestViewFactory.scala
+++ b/core/.js/src/test/scala/io/udash/testing/TestViewFactory.scala
@@ -20,13 +20,16 @@ class TestView extends ContainerView {
   var closed = false
 
   override def renderChild(view: Option[View]): Unit = {
-    view.foreach(_.getTemplate)
+    super.renderChild(view)
     lastChild = view.orNull
   }
 
   override def getTemplate: Modifier = {
     renderingCounter += 1
-    div().render
+    div(
+      toString,
+      childViewContainer
+    )
   }
 
   override def onClose(): Unit = {
@@ -40,7 +43,7 @@ class TestFinalView extends View {
 
   override def getTemplate: Modifier = {
     renderingCounter += 1
-    div().render
+    span(toString)
   }
 }
 

--- a/core/.js/src/test/scala/io/udash/testing/TestViewFactoryRegistry.scala
+++ b/core/.js/src/test/scala/io/udash/testing/TestViewFactoryRegistry.scala
@@ -5,12 +5,12 @@ import io.udash._
 import scala.collection.mutable
 
 class TestViewFactoryRegistry(vp: Map[TestState, () => ViewFactory[_ <: TestState]],
-  default: ViewFactory[ErrorState.type]) extends ViewFactoryRegistry[TestState] {
+  default: () => ViewFactory[_ <: TestState]) extends ViewFactoryRegistry[TestState] {
   var statesHistory: mutable.ArrayBuffer[TestState] = mutable.ArrayBuffer.empty
 
   override def matchStateToResolver(state: TestState): ViewFactory[_ <: TestState] = {
     if (state == ThrowExceptionState) throw new RuntimeException("ThrowExceptionState")
     statesHistory.append(state)
-    vp.get(state).map(_.apply()).getOrElse(default)
+    vp.get(state).map(_.apply()).getOrElse(default())
   }
 }

--- a/core/.js/src/test/scala/io/udash/view/ViewRendererTest.scala
+++ b/core/.js/src/test/scala/io/udash/view/ViewRendererTest.scala
@@ -134,13 +134,37 @@ class ViewRendererTest extends UdashFrontendTest {
 
       renderer.renderView(Iterator.empty, rootView :: Nil)
 
+      endpoint.childNodes.length shouldBe 2
       endpoint.children.length shouldBe 1
-      val first = endpoint.lastChild
+      val first = endpoint.firstChild
+      val last = endpoint.lastChild
+      val content = endpoint.outerHTML
 
       renderer.renderView(Iterator.empty, rootView2 :: Nil)
 
+      endpoint.childNodes.length shouldBe 2
       endpoint.children.length shouldBe 1
-      endpoint.lastChild should not be first
+      val first2 = endpoint.firstChild
+      val last2 = endpoint.lastChild
+      val content2 = endpoint.outerHTML
+      first2 should not be first
+      last2 should not be last
+      content2 should not be content
+
+      renderer.renderView(Iterator(rootView2), rootView :: Nil)
+
+      endpoint.childNodes.length shouldBe 2
+      endpoint.children.length shouldBe 1
+      endpoint.firstChild should not be first
+      endpoint.lastChild should not be last
+      endpoint.outerHTML should not be markup
+
+      renderer.renderView(Iterator(rootView2), Nil)
+      endpoint.childNodes.length shouldBe 2
+      endpoint.children.length shouldBe 1
+      endpoint.firstChild shouldBe first2
+      endpoint.lastChild shouldBe last2
+      endpoint.outerHTML shouldBe content2
     }
 
     "handle replacing the whole hierarchy" in testReplace(emptyComponent())


### PR DESCRIPTION
Stacked on #583 

- handle case where container views are swapped, e.g. Root -> View1 -> View2 => Root -> View2 -> View1, which would not render due to child container cycle
- handle non-element nodes in child containers cleanup