### PR TITLE
Added support diferent sides at bootstrap's auto margin

### DIFF
--- a/bootstrap4/.js/src/main/scala/io/udash/bootstrap/utils/BootstrapStyles.scala
+++ b/bootstrap4/.js/src/main/scala/io/udash/bootstrap/utils/BootstrapStyles.scala
@@ -221,7 +221,8 @@ trait BootstrapStyles {
     def shrink1(breakpoint: ResponsiveBreakpoint = ResponsiveBreakpoint.All) =
       CssStyleName(s"flex${breakpoint.classMarker}-shrink-1")
 
-    def autoMargin(side: Side = Side.All) = CssStyleName(s"m${side.classMarker}-auto")
+    def autoMargin(side: Side = Side.All, breakpoint: ResponsiveBreakpoint = ResponsiveBreakpoint.All) =
+      CssStyleName(s"m${side.classMarker}${breakpoint.classMarker}-auto")
 
     def nowrap(breakpoint: ResponsiveBreakpoint = ResponsiveBreakpoint.All) =
       CssStyleName(s"flex${breakpoint.classMarker}-nowrap")


### PR DESCRIPTION
bootstrap supported an auto margin like this `ml-sm-auto` and it is impossibly to constract via type safe methods.

Introduced a way.

Source: https://getbootstrap.com/docs/4.0/utilities/spacing/