### PR TITLE
Added `udash.local` and `guide.udash.local` to guide's vhost.

### DIFF
--- a/guide/backend/src/main/scala/io/udash/web/server/ApplicationServer.scala
+++ b/guide/backend/src/main/scala/io/udash/web/server/ApplicationServer.scala
@@ -26,13 +26,13 @@ class ApplicationServer(val port: Int, homepageResourceBase: String, guideResour
   }
 
   private val homepage = {
-    val ctx = createContextHandler(Array("udash.io", "www.udash.io", "127.0.0.1"))
+    val ctx = createContextHandler(Array("udash.io", "www.udash.io", "udash.local", "127.0.0.1"))
     ctx.addServlet(createStaticHandler(homepageResourceBase), "/*")
     ctx
   }
 
   private val guide = {
-    val ctx = createContextHandler(Array("guide.udash.io", "www.guide.udash.io", "127.0.0.2", "localhost"))
+    val ctx = createContextHandler(Array("guide.udash.io", "www.guide.udash.io", "guide.udash.local", "127.0.0.2", "localhost"))
     ctx.getSessionHandler.addEventListener(new org.atmosphere.cpr.SessionSupport())
     ctx.addServlet(createStaticHandler(guideResourceBase), "/*")
 


### PR DESCRIPTION
Right now for local development anyone should use `127.0.0.2` as host to access to guide.

Unfortunately not all systems route `127.0.0.0/8` to loopback interface, for example macOS.

That forces a developer to hack this code or put `guide.udash.io` to `/etc/hosts` that might create a error in the future when he forget to remove it.