### PR TITLE
Remove `case class Url`

### DIFF
--- a/auth/.js/src/test/scala/io/udash/auth/AuthApplicationTest.scala
+++ b/auth/.js/src/test/scala/io/udash/auth/AuthApplicationTest.scala
@@ -1,6 +1,6 @@
 package io.udash.auth
 
-import io.udash.Application
+import io.udash.{Application, Url}
 import io.udash.core._
 import io.udash.routing.RoutingRegistry
 import io.udash.testing.AsyncUdashFrontendTest
@@ -28,8 +28,8 @@ class AuthApplicationTest extends AsyncUdashFrontendTest with AuthTestUtils with
       case "/s3" => ThirdState
     }
 
-    override def matchUrl(url: Url): TestStates = url2State(url.value)
-    override def matchState(state: TestStates): Url = Url(state2Url(state))
+    override def matchUrl(url: Url): TestStates = url2State(url)
+    override def matchState(state: TestStates): Url = state2Url(state)
   }
 
   "AuthApplication" should {

--- a/bootstrap4/.js/src/main/scala/io/udash/bootstrap/carousel/UdashCarousel.scala
+++ b/bootstrap4/.js/src/main/scala/io/udash/bootstrap/carousel/UdashCarousel.scala
@@ -290,7 +290,7 @@ case class UdashCarouselSlide(imgSrc: Url)(caption: Modifier*) {
 
   lazy val render: Node = {
     Seq(
-      img(src := imgSrc.value, BootstrapStyles.Sizing.width100),
+      img(src := imgSrc, BootstrapStyles.Sizing.width100),
       div(BootstrapStyles.Carousel.caption)(
         caption
       )

--- a/bootstrap4/.js/src/main/scala/io/udash/bootstrap/dropdown/UdashDropdown.scala
+++ b/bootstrap4/.js/src/main/scala/io/udash/bootstrap/dropdown/UdashDropdown.scala
@@ -151,7 +151,7 @@ object UdashDropdown {
       case Text(text) =>
         span(BootstrapStyles.Dropdown.itemText, text).render
       case Link(title, url) =>
-        a(BootstrapStyles.Dropdown.item, href := url.value)(title).render
+        a(BootstrapStyles.Dropdown.item, href := url)(title).render
       case Button(title, callback) =>
         button(BootstrapStyles.Dropdown.item, onclick :+= ((_: Event) => {
           callback()

--- a/bootstrap4/.js/src/main/scala/io/udash/bootstrap/nav/UdashNav.scala
+++ b/bootstrap4/.js/src/main/scala/io/udash/bootstrap/nav/UdashNav.scala
@@ -75,7 +75,7 @@ object UdashNav {
   /** Default breadcrumb model factory. */
   val defaultItemFactory: (ReadableProperty[NavItem], Binding.NestedInterceptor) => Element = {
     (item, nested) => a(
-      nested(href.bind(item.transform(_.link.value))),
+      nested(href.bind(item.transform(_.link))),
       nested(bind(item.transform(_.name))),
       BootstrapStyles.Navigation.link
     ).render

--- a/bootstrap4/.js/src/main/scala/io/udash/bootstrap/utils/BootstrapImplicits.scala
+++ b/bootstrap4/.js/src/main/scala/io/udash/bootstrap/utils/BootstrapImplicits.scala
@@ -1,15 +1,9 @@
 package io.udash.bootstrap.utils
 
-import io.udash.Url
 import io.udash.bindings.modifiers.Binding
-import org.scalajs.dom.Element
-import scalatags.JsDom
-import scalatags.JsDom.GenericAttr
 import scalatags.JsDom.all._
 
 trait BootstrapImplicits {
-  implicit val urlAttrValue: AttrValue[Url] = (t: Element, a: JsDom.Attr, v: Url) => new GenericAttr[String].apply(t, a, v.value)
-
   implicit def withoutNested(modifier: Modifier): Binding.NestedInterceptor => Modifier = _ => modifier
   implicit def stringWithoutNested(modifier: String): Binding.NestedInterceptor => Modifier = _ => modifier
 }

--- a/bootstrap4/.js/src/test/scala/io/udash/bootstrap/breadcrumb/UdashBreadcrumbsTest.scala
+++ b/bootstrap4/.js/src/test/scala/io/udash/bootstrap/breadcrumb/UdashBreadcrumbsTest.scala
@@ -53,9 +53,9 @@ class UdashBreadcrumbsTest extends UdashCoreFrontendTest {
 
     "work with default elements" in {
       val pages = SeqProperty(
-        new UdashBreadcrumbs.Breadcrumb("Home", Url("https://udash.io/")),
-        new UdashBreadcrumbs.Breadcrumb("Guide", Url("https://guide.udash.io/")),
-        new UdashBreadcrumbs.Breadcrumb("RPC", Url("https://guide.udash.io/rpc"))
+        new UdashBreadcrumbs.Breadcrumb("Home", "https://udash.io/"),
+        new UdashBreadcrumbs.Breadcrumb("Guide", "https://guide.udash.io/"),
+        new UdashBreadcrumbs.Breadcrumb("RPC", "https://guide.udash.io/rpc")
       )
       val breadcrumbs = UdashBreadcrumbs.default(pages)()
       val el = breadcrumbs.render
@@ -63,7 +63,7 @@ class UdashBreadcrumbsTest extends UdashCoreFrontendTest {
       el.getElementsByTagName("a").length should be(3)
       el.textContent should be("HomeGuideRPC")
 
-      pages.append(new UdashBreadcrumbs.Breadcrumb("Frontend", Url("https://guide.udash.io/rpc/frontend")))
+      pages.append(new UdashBreadcrumbs.Breadcrumb("Frontend", "https://guide.udash.io/rpc/frontend"))
 
       el.getElementsByTagName("a").length should be(4)
       el.textContent should be("HomeGuideRPCFrontend")
@@ -73,7 +73,7 @@ class UdashBreadcrumbsTest extends UdashCoreFrontendTest {
       el.getElementsByTagName("a").length should be(3)
       el.textContent should be("HomeRPCFrontend")
 
-      pages.elemProperties(1).set(new UdashBreadcrumbs.Breadcrumb("X", Url("http://google.com")))
+      pages.elemProperties(1).set(new UdashBreadcrumbs.Breadcrumb("X", "http://google.com"))
 
       el.getElementsByTagName("a").length should be(3)
       el.textContent should be("HomeXFrontend")

--- a/bootstrap4/.js/src/test/scala/io/udash/bootstrap/carousel/UdashCarouselTest.scala
+++ b/bootstrap4/.js/src/test/scala/io/udash/bootstrap/carousel/UdashCarouselTest.scala
@@ -16,7 +16,7 @@ import scala.util.Random
 class UdashCarouselTest extends AsyncUdashCoreFrontendTest {
 
   "UdashCarousel component" should {
-    val omitUrl = Url("//:0")
+    val omitUrl = "//:0"
     def newSlide() = UdashCarouselSlide(omitUrl)(BigInt.probablePrime(80, Random).toString(36))
     def slides() = SeqProperty((1 to 10).map(_ => newSlide()))
 

--- a/bootstrap4/.js/src/test/scala/io/udash/bootstrap/dropdown/UdashDropdownTest.scala
+++ b/bootstrap4/.js/src/test/scala/io/udash/bootstrap/dropdown/UdashDropdownTest.scala
@@ -13,10 +13,10 @@ class UdashDropdownTest extends UdashCoreFrontendTest {
 
   private val elements: Seq[DefaultDropdownItem] =Seq(
     DefaultDropdownItem.Header("Header"),
-    DefaultDropdownItem.Link("Link 1", Url("#")),
-    DefaultDropdownItem.Link("Link 2", Url("#")),
+    DefaultDropdownItem.Link("Link 1", "#"),
+    DefaultDropdownItem.Link("Link 2", "#"),
     DefaultDropdownItem.Divider,
-    DefaultDropdownItem.Disabled(DefaultDropdownItem.Link("Link 3", Url("#")))
+    DefaultDropdownItem.Disabled(DefaultDropdownItem.Link("Link 3", "#"))
   )
 
   "UdashDropdown component" should {
@@ -123,7 +123,7 @@ class UdashDropdownTest extends UdashCoreFrontendTest {
 
       el.childNodes(1).childNodes.length should be(els.get.length)
 
-      val tmp: DefaultDropdownItem.Link = DefaultDropdownItem.Link("New", Url("#"))
+      val tmp: DefaultDropdownItem.Link = DefaultDropdownItem.Link("New", "#")
       els.append(tmp)
       el.childNodes(1).childNodes.length should be(els.get.length)
       els.remove(tmp)

--- a/core/.js/src/main/scala/io/udash/Application.scala
+++ b/core/.js/src/main/scala/io/udash/Application.scala
@@ -10,7 +10,7 @@ import org.scalajs.dom.Element
 /**
  * Root application which is used to start single instance of app.
  *
- * @param routingRegistry     [[io.udash.routing.RoutingRegistry]] implementation, which will be used to match [[io.udash.core.Url]] to [[io.udash.core.State]]
+ * @param routingRegistry     [[io.udash.routing.RoutingRegistry]] implementation, which will be used to match [[io.udash.Url]] to [[io.udash.core.State]]
  * @param viewFactoryRegistry [[io.udash.core.ViewFactoryRegistry]] implementation, which will be used to match [[io.udash.core.State]] into [[io.udash.core.ViewFactory]]
  * @tparam HierarchyRoot Should be a sealed trait which extends [[io.udash.core.State]].
  */

--- a/core/.js/src/main/scala/io/udash/core/Definitions.scala
+++ b/core/.js/src/main/scala/io/udash/core/Definitions.scala
@@ -1,14 +1,7 @@
 package io.udash.core
 
-import io.udash.properties.HasModelPropertyCreator
 import org.scalajs.dom._
 import scalatags.generic.Modifier
-
-/**
-  * Url wrapper - just for avoiding strings.
-  */
-case class Url(value: String) extends AnyVal
-object Url extends HasModelPropertyCreator[Url]
 
 /**
   * The Presenter should contain all business logic of a view: user interaction callbacks, server communication.

--- a/core/.js/src/main/scala/io/udash/package.scala
+++ b/core/.js/src/main/scala/io/udash/package.scala
@@ -10,8 +10,7 @@ package object udash
   final val EmptyPresenter = io.udash.core.EmptyPresenter
 
   // Definitions
-  final val Url = io.udash.core.Url
-  type Url = io.udash.core.Url
+  type Url = String
 
   type Presenter[S <: State] = io.udash.core.Presenter[S]
 

--- a/core/.js/src/main/scala/io/udash/routing/RoutingRegistry.scala
+++ b/core/.js/src/main/scala/io/udash/routing/RoutingRegistry.scala
@@ -1,33 +1,33 @@
 package io.udash.routing
 
-import io.udash.core.{State, Url}
+import io.udash.{State, Url}
 
 /**
  * The implementation of this trait should be injected to [[io.udash.Application]].
- * It should implement a bidirectional mapping between [[io.udash.core.Url]] and [[io.udash.core.State]].
+ * It should implement a bidirectional mapping between [[io.udash.Url]] and [[io.udash.core.State]].
  */
 trait RoutingRegistry[HierarchyRoot <: State] {
   def matchUrl(url: Url): HierarchyRoot
   def matchState(state: HierarchyRoot): Url
 
-  protected def bidirectional(pf: PartialFunction[String, HierarchyRoot]): (PartialFunction[String, HierarchyRoot], PartialFunction[HierarchyRoot, String]) =
-  macro com.avsystem.commons.macros.misc.BidirectionalMacro.impl[String, HierarchyRoot]
+  protected def bidirectional(pf: PartialFunction[Url, HierarchyRoot]): (PartialFunction[Url, HierarchyRoot], PartialFunction[HierarchyRoot, Url]) =
+  macro com.avsystem.commons.macros.misc.BidirectionalMacro.impl[Url, HierarchyRoot]
 
   import RoutingRegistry._
 
   protected final val / = RoutingRegistry./
 
-  protected implicit def stringRoutingOps(str: String): StringRoutingOps =
+  protected implicit def stringRoutingOps(str: Url): StringRoutingOps =
     new StringRoutingOps(str)
 }
 
 object RoutingRegistry {
   implicit final class StringRoutingOps(private val left: String) extends AnyVal {
-    def /(right: Any): String = RoutingRegistry./(left, right.toString)
+    def /(right: Any): Url = RoutingRegistry./(left, right.toString)
   }
 
   object / {
-    def unapply(path: String): Option[(String, String)] = {
+    def unapply(path: Url): Option[(Url, Url)] = {
       val strippedPath = path.stripSuffix("/")
       Some(strippedPath.lastIndexOf("/")).collect {
         case splitIndex if splitIndex >= 0 =>
@@ -37,7 +37,7 @@ object RoutingRegistry {
       }
     }
 
-    def apply(left: String, right: String): String =
+    def apply(left: Url, right: Url): Url =
       left + "/" + right
   }
 }

--- a/core/.js/src/main/scala/io/udash/routing/UrlChangeProvider.scala
+++ b/core/.js/src/main/scala/io/udash/routing/UrlChangeProvider.scala
@@ -1,7 +1,7 @@
 package io.udash.routing
 
 import com.avsystem.commons._
-import io.udash.core.Url
+import io.udash.Url
 import io.udash.properties.MutableBufferRegistration
 import io.udash.utils.Registration
 import org.scalajs.dom
@@ -45,11 +45,11 @@ final class WindowUrlFragmentChangeProvider extends UrlChangeProvider {
     new MutableBufferRegistration(callbacks, callback, Opt.Empty)
   }
 
-  override def currentFragment: Url = Url(window.location.hash.stripPrefix("#"))
+  override def currentFragment: Url = window.location.hash.stripPrefix("#")
 
   override def changeFragment(url: Url, replaceCurrent: Boolean): Unit = {
-    if (replaceCurrent) window.location.replace(window.location.href.takeWhile(_ != '#') + "#" + url.value)
-    else window.location.hash = url.value
+    if (replaceCurrent) window.location.replace(window.location.href.takeWhile(_ != '#') + "#" + url)
+    else window.location.hash = url
   }
 }
 
@@ -107,7 +107,7 @@ final class WindowUrlPathChangeProvider extends UrlChangeProvider {
           val (samePath, sameHash, sameOrigin) =
             (isSamePath(location, newUrl), isSameHash(location, newUrl), isSameOrigin(location, newUrl))
           if (!shouldIgnoreClick(event, target, href, samePath, sameHash, sameOrigin)) {
-            if (!samePath) changeFragment(Url(href))
+            if (!samePath) changeFragment(href)
             event.preventDefault()
           }
         }
@@ -122,14 +122,14 @@ final class WindowUrlPathChangeProvider extends UrlChangeProvider {
   }
 
   override def changeFragment(url: Url, replaceCurrent: Boolean): Unit = {
-    (null, "", url.value) |> (
+    (null, "", url) |> (
       if (replaceCurrent) window.history.replaceState(_: js.Any, _: String, _: String)
       else window.history.pushState(_: js.Any, _: String, _: String)
       ).tupled
-    val withoutHash = Url(url.value.takeWhile(_ != '#'))
+    val withoutHash = url.takeWhile(_ != '#')
     callbacks.foreach(_.apply(withoutHash))
   }
 
   override def currentFragment: Url =
-    Url(window.history.state.opt.map(_.asInstanceOf[js.Dynamic].url.toString).getOrElse(window.location.pathname))
+    window.history.state.opt.map(_.asInstanceOf[js.Dynamic].url.toString).getOrElse(window.location.pathname)
 }

--- a/core/.js/src/main/scala/io/udash/routing/UrlLogging.scala
+++ b/core/.js/src/main/scala/io/udash/routing/UrlLogging.scala
@@ -12,7 +12,7 @@ trait UrlLogging[S >: Null <: GState[S]] extends CrossLogging { app: Application
   protected def log(url: String, referrer: Option[String]): Unit
 
   app.onStateChange(event =>
-    Try(log(matchState(event.currentState).value, Try(matchState(event.oldState).value).toOption))
+    Try(log(matchState(event.currentState), Try(matchState(event.oldState)).toOption))
       .failed
       .foreach(t => logger.warn("Logging url change failed: {}", t.getMessage)))
 }

--- a/core/.js/src/main/scala/io/udash/utils/FileUploader.scala
+++ b/core/.js/src/main/scala/io/udash/utils/FileUploader.scala
@@ -61,7 +61,7 @@ class FileUploader(url: Url) {
     xhr.addEventListener("abort", (_: Event) =>
       p.subProp(_.state).set(FileUploadState.Cancelled)
     )
-    xhr.open(method = "POST", url = url.value)
+    xhr.open(method = "POST", url = url)
     xhr.send(data)
 
     p

--- a/core/.js/src/test/scala/io/udash/ApplicationTest.scala
+++ b/core/.js/src/test/scala/io/udash/ApplicationTest.scala
@@ -6,7 +6,7 @@ class ApplicationTest extends UdashFrontendTest with TestRouting {
 
   "Application" should {
     initTestRouting(default = () => new TestViewFactory[TestState])
-    val initUrl = Url("/")
+    val initUrl = "/"
     val urlProvider: TestUrlChangeProvider = new TestUrlChangeProvider(initUrl)
     val app = new Application[TestState](routing, vpRegistry, urlProvider)
 
@@ -20,18 +20,18 @@ class ApplicationTest extends UdashFrontendTest with TestRouting {
 
     "change URL basing on state" in {
       app.goTo(NextObjectState)
-      urlProvider.currUrl.value should be("/next")
+      urlProvider.currUrl should be("/next")
       app.goTo(ObjectState)
-      urlProvider.currUrl.value should be("/")
+      urlProvider.currUrl should be("/")
       app.goTo(ClassState("abc", 1))
-      urlProvider.currUrl.value should be("/abc/1")
+      urlProvider.currUrl should be("/abc/1")
       app.goTo(ClassState("abcd", 234))
-      urlProvider.currUrl.value should be("/abcd/234")
+      urlProvider.currUrl should be("/abcd/234")
     }
 
     "redirect to URL" in {
       app.redirectTo("http://www.avsystem.com/")
-      urlProvider.currUrl.value should be("http://www.avsystem.com/")
+      urlProvider.currUrl should be("http://www.avsystem.com/")
     }
 
     "register callback for state change" in {
@@ -76,10 +76,10 @@ class ApplicationTest extends UdashFrontendTest with TestRouting {
     }
 
     "return URL of state" in {
-      app.matchState(ObjectState).value should be("/")
-      app.matchState(NextObjectState).value should be("/next")
-      app.matchState(ClassState("abc", 1)).value should be("/abc/1")
-      app.matchState(ClassState("abcd", 234)).value should be("/abcd/234")
+      app.matchState(ObjectState) should be("/")
+      app.matchState(NextObjectState) should be("/next")
+      app.matchState(ClassState("abc", 1)) should be("/abc/1")
+      app.matchState(ClassState("abcd", 234)) should be("/abcd/234")
     }
   }
 }

--- a/core/.js/src/test/scala/io/udash/routing/RoutingEngineTest.scala
+++ b/core/.js/src/test/scala/io/udash/routing/RoutingEngineTest.scala
@@ -42,7 +42,7 @@ class RoutingEngineTest extends UdashFrontendTest with TestRouting {
 
       testClosedAndReset(_ => false)
 
-      routingEngine.handleUrl(Url("/"))
+      routingEngine.handleUrl("/")
 
       renderer.views.size should be(2)
       renderer.views(0) should be(rootViewFactory.view)
@@ -51,7 +51,7 @@ class RoutingEngineTest extends UdashFrontendTest with TestRouting {
       renderer.lastPathToAdd.size should be(2)
       testClosedAndReset(_ => false)
 
-      routingEngine.handleUrl(Url("/next"))
+      routingEngine.handleUrl("/next")
 
       renderer.views.size should be(3)
       renderer.views(0) should be(rootViewFactory.view)
@@ -61,7 +61,7 @@ class RoutingEngineTest extends UdashFrontendTest with TestRouting {
       renderer.lastPathToAdd should be(nextObjectViewFactory.view :: Nil)
       testClosedAndReset(_ => false)
 
-      routingEngine.handleUrl(Url("/"))
+      routingEngine.handleUrl("/")
 
       renderer.views.size should be(2)
       renderer.views(0) should be(rootViewFactory.view)
@@ -73,7 +73,7 @@ class RoutingEngineTest extends UdashFrontendTest with TestRouting {
         case _ => false
       }
 
-      routingEngine.handleUrl(Url("/abc/1"))
+      routingEngine.handleUrl("/abc/1")
 
       renderer.views.size should be(2)
       renderer.views(0) should be(rootViewFactory.view)
@@ -85,7 +85,7 @@ class RoutingEngineTest extends UdashFrontendTest with TestRouting {
         case _ => false
       }
 
-      routingEngine.handleUrl(Url("/abcd/234"))
+      routingEngine.handleUrl("/abcd/234")
 
       renderer.views.size should be(2)
       renderer.views(0) should be(rootViewFactory.view)
@@ -97,7 +97,7 @@ class RoutingEngineTest extends UdashFrontendTest with TestRouting {
         case _ => false
       }
 
-      routingEngine.handleUrl(Url("/next"))
+      routingEngine.handleUrl("/next")
 
       renderer.views.size should be(3)
       renderer.views(0) should be(rootViewFactory.view)
@@ -111,7 +111,7 @@ class RoutingEngineTest extends UdashFrontendTest with TestRouting {
         case _ => false
       }
 
-      routingEngine.handleUrl(Url("/next"), fullReload = true)
+      routingEngine.handleUrl("/next", fullReload = true)
 
       renderer.views.size should be(3)
       renderer.views(0) should be(rootViewFactory.view)
@@ -125,7 +125,7 @@ class RoutingEngineTest extends UdashFrontendTest with TestRouting {
         case _ => false
       }
 
-      routingEngine.handleUrl(Url("/root/1"))
+      routingEngine.handleUrl("/root/1")
 
       rootViewFactory.count shouldBe 2
       testClosedAndReset {
@@ -133,7 +133,7 @@ class RoutingEngineTest extends UdashFrontendTest with TestRouting {
         case _ => false
       }
 
-      routingEngine.handleUrl(Url("/root/2"))
+      routingEngine.handleUrl("/root/2")
 
       rootViewFactory.count shouldBe 2
       testClosedAndReset(_ => false)
@@ -149,81 +149,81 @@ class RoutingEngineTest extends UdashFrontendTest with TestRouting {
         calls += 1
       })
 
-      routingEngine.handleUrl(Url("/"))
+      routingEngine.handleUrl("/")
 
       calls should be(1)
       lastCallbackEvent.oldState should be(null)
       lastCallbackEvent.currentState should be(ObjectState)
 
-      routingEngine.handleUrl(Url("/next"))
+      routingEngine.handleUrl("/next")
 
       calls should be(2)
       lastCallbackEvent.oldState should be(ObjectState)
       lastCallbackEvent.currentState should be(NextObjectState)
 
-      routingEngine.handleUrl(Url("/"))
+      routingEngine.handleUrl("/")
 
       calls should be(3)
       lastCallbackEvent.oldState should be(NextObjectState)
       lastCallbackEvent.currentState should be(ObjectState)
 
-      routingEngine.handleUrl(Url("/"))
+      routingEngine.handleUrl("/")
 
       calls should be(3)
       lastCallbackEvent.oldState should be(NextObjectState)
       lastCallbackEvent.currentState should be(ObjectState)
 
-      routingEngine.handleUrl(Url("/abc/1"))
+      routingEngine.handleUrl("/abc/1")
 
       calls should be(4)
       lastCallbackEvent.oldState should be(ObjectState)
       lastCallbackEvent.currentState should be(ClassState("abc", 1))
 
-      routingEngine.handleUrl(Url("/abc/1"))
+      routingEngine.handleUrl("/abc/1")
 
       calls should be(4)
       lastCallbackEvent.oldState should be(ObjectState)
       lastCallbackEvent.currentState should be(ClassState("abc", 1))
 
-      routingEngine.handleUrl(Url("/abcd/234"))
+      routingEngine.handleUrl("/abcd/234")
 
       calls should be(5)
       lastCallbackEvent.oldState should be(ClassState("abc", 1))
       lastCallbackEvent.currentState should be(ClassState("abcd", 234))
 
-      routingEngine.handleUrl(Url("/next"))
+      routingEngine.handleUrl("/next")
 
       calls should be(6)
       lastCallbackEvent.oldState should be(ClassState("abcd", 234))
       lastCallbackEvent.currentState should be(NextObjectState)
 
-      routingEngine.handleUrl(Url("/next"))
+      routingEngine.handleUrl("/next")
 
       calls should be(6)
       lastCallbackEvent.oldState should be(ClassState("abcd", 234))
       lastCallbackEvent.currentState should be(NextObjectState)
 
       reg.cancel()
-      routingEngine.handleUrl(Url("/abcd/123"))
+      routingEngine.handleUrl("/abcd/123")
 
       calls should be(6)
       lastCallbackEvent.oldState should be(ClassState("abcd", 234))
       lastCallbackEvent.currentState should be(NextObjectState)
 
       reg.restart()
-      routingEngine.handleUrl(Url("/next"))
+      routingEngine.handleUrl("/next")
 
       calls should be(7)
       lastCallbackEvent.oldState should be(ClassState("abcd", 123))
       lastCallbackEvent.currentState should be(NextObjectState)
 
-      routingEngine.handleUrl(Url("/next"))
+      routingEngine.handleUrl("/next")
 
       calls should be(7)
       lastCallbackEvent.oldState should be(ClassState("abcd", 123))
       lastCallbackEvent.currentState should be(NextObjectState)
 
-      routingEngine.handleUrl(Url("/next"), fullReload = true)
+      routingEngine.handleUrl("/next", fullReload = true)
 
       calls should be(8)
       lastCallbackEvent.oldState should be(NextObjectState)
@@ -233,28 +233,28 @@ class RoutingEngineTest extends UdashFrontendTest with TestRouting {
     "return valid current app state" in {
       initTestRoutingEngine()
 
-      routingEngine.handleUrl(Url("/"))
+      routingEngine.handleUrl("/")
       routingEngine.currentState should be(ObjectState)
 
-      routingEngine.handleUrl(Url("/next"))
+      routingEngine.handleUrl("/next")
       routingEngine.currentState should be(NextObjectState)
 
-      routingEngine.handleUrl(Url("/"))
+      routingEngine.handleUrl("/")
       routingEngine.currentState should be(ObjectState)
 
-      routingEngine.handleUrl(Url("/abc/1"))
+      routingEngine.handleUrl("/abc/1")
       routingEngine.currentState should be(ClassState("abc", 1))
 
-      routingEngine.handleUrl(Url("/abcd/234"))
+      routingEngine.handleUrl("/abcd/234")
       routingEngine.currentState should be(ClassState("abcd", 234))
 
-      routingEngine.handleUrl(Url("/next"))
+      routingEngine.handleUrl("/next")
       routingEngine.currentState should be(NextObjectState)
 
-      routingEngine.handleUrl(Url("/next"), fullReload = true)
+      routingEngine.handleUrl("/next", fullReload = true)
       routingEngine.currentState should be(NextObjectState)
 
-      routingEngine.handleUrl(Url("/abcd/234"), fullReload = true)
+      routingEngine.handleUrl("/abcd/234", fullReload = true)
       routingEngine.currentState should be(ClassState("abcd", 234))
     }
 
@@ -295,37 +295,37 @@ class RoutingEngineTest extends UdashFrontendTest with TestRouting {
 
       initTestRoutingEngine(state2vp = state2VP.view.mapValues(() => _).toMap)
 
-      routingEngine.handleUrl(Url("/"))
+      routingEngine.handleUrl("/")
       renderer.views.size should be(0)
 
-      routingEngine.handleUrl(Url("/next"))
+      routingEngine.handleUrl("/next")
       renderer.views.size should be(0)
 
-      routingEngine.handleUrl(Url("/"))
+      routingEngine.handleUrl("/")
       renderer.views.size should be(0)
 
-      routingEngine.handleUrl(Url("/abc/1"))
+      routingEngine.handleUrl("/abc/1")
       renderer.views.size should be(0)
 
       //handleState exception doesn't prevent routing to valid state
-      routingEngine.handleUrl(Url("/root"))
+      routingEngine.handleUrl("/root")
       renderer.views shouldBe Seq(rootView)
 
-      routingEngine.handleUrl(Url("/abcd/234"))
+      routingEngine.handleUrl("/abcd/234")
       renderer.views shouldBe Seq(rootView, class2View)
 
       //onClose exception doesn't prevent routing to valid state
-      routingEngine.handleUrl(Url("/root"))
+      routingEngine.handleUrl("/root")
       renderer.views shouldBe Seq(rootView)
 
-      routingEngine.handleUrl(Url("/abcd/234"))
+      routingEngine.handleUrl("/abcd/234")
       renderer.views shouldBe Seq(rootView, class2View)
 
       //onClose exception doesn't prevent routing to valid state
-      routingEngine.handleUrl(Url("/root"), fullReload = true)
+      routingEngine.handleUrl("/root", fullReload = true)
       renderer.views shouldBe Seq(rootView)
 
-      routingEngine.handleUrl(Url("/next"))
+      routingEngine.handleUrl("/next")
       renderer.views shouldBe Seq(rootView)
     }
 
@@ -346,21 +346,21 @@ class RoutingEngineTest extends UdashFrontendTest with TestRouting {
 
       initTestRoutingEngine(state2vp = state2VP)
 
-      routingEngine.handleUrl(Url("/root"))
+      routingEngine.handleUrl("/root")
 
       renderer.views shouldBe Seq(staticView)
       renderer.lastSubPathToLeave shouldBe empty
       renderer.lastPathToAdd.size shouldBe 1
       staticCreateCount shouldBe 1
 
-      routingEngine.handleUrl(Url("/root/1"))
+      routingEngine.handleUrl("/root/1")
 
       renderer.views shouldBe Seq(staticView)
       renderer.lastSubPathToLeave shouldBe List(staticView)
       renderer.lastPathToAdd.size shouldBe 0
       staticCreateCount shouldBe 1
 
-      routingEngine.handleUrl(Url("/root/2"))
+      routingEngine.handleUrl("/root/2")
 
       renderer.views shouldBe Seq(staticView)
       renderer.lastSubPathToLeave shouldBe List(staticView)

--- a/core/.js/src/test/scala/io/udash/routing/UrlLoggingTest.scala
+++ b/core/.js/src/test/scala/io/udash/routing/UrlLoggingTest.scala
@@ -1,7 +1,6 @@
 package io.udash.routing
 
 import io.udash._
-import io.udash.core.Url
 import io.udash.testing._
 
 import scala.collection.mutable.ListBuffer
@@ -14,7 +13,7 @@ class UrlLoggingTest extends AsyncUdashFrontendTest with TestRouting {
       new TestViewFactory[TestState]: ViewFactory[_ <: TestState]
 
       initTestRouting(default = () => new TestViewFactory[TestState])
-      val initUrl = Url("/")
+      val initUrl = "/"
       val urlProvider: TestUrlChangeProvider = new TestUrlChangeProvider(initUrl)
       val app = new Application[TestState](routing, vpRegistry, urlProvider) with UrlLogging[TestState] {
         override protected def log(url: String, referrer: Option[String]): Unit = {
@@ -25,7 +24,7 @@ class UrlLoggingTest extends AsyncUdashFrontendTest with TestRouting {
 
       val urls = Seq("/", "/next", "/abc/1", "/next")
       val expected = (urls.head, Some("")) :: urls.sliding(2).map { case Seq(prev, current) => (current, Some(prev)) }.toList
-      urls.foreach(str => app.goTo(routing.matchUrl(Url(str))))
+      urls.foreach(str => app.goTo(routing.matchUrl(str)))
       retrying(urlWithRef.toList shouldBe expected)
     }
   }

--- a/core/.js/src/test/scala/io/udash/routing/WindowUrlFragmentChangeProviderTest.scala
+++ b/core/.js/src/test/scala/io/udash/routing/WindowUrlFragmentChangeProviderTest.scala
@@ -14,9 +14,9 @@ class WindowUrlFragmentChangeProviderTest extends AsyncUdashFrontendTest {
       val originalHref = dom.window.location.href
       val fragment = "lol"
 
-      provider.changeFragment(Url(fragment), replaceCurrent = false)
+      provider.changeFragment(fragment, replaceCurrent = false)
 
-      provider.currentFragment.value shouldBe fragment
+      provider.currentFragment shouldBe fragment
       dom.window.location.hash shouldBe "#" + fragment
       retrying {
         //sometimes history takes time to catch up here
@@ -35,10 +35,10 @@ class WindowUrlFragmentChangeProviderTest extends AsyncUdashFrontendTest {
       val historyLength = dom.window.history.length
       val fragment = "lol"
 
-      provider.changeFragment(Url(fragment), replaceCurrent = true)
+      provider.changeFragment(fragment, replaceCurrent = true)
 
       retrying {
-        provider.currentFragment.value shouldBe fragment
+        provider.currentFragment shouldBe fragment
         dom.window.location.hash shouldBe "#" + fragment
         dom.window.history.length shouldBe historyLength
       }

--- a/core/.js/src/test/scala/io/udash/routing/WindowUrlPathChangeProviderTest.scala
+++ b/core/.js/src/test/scala/io/udash/routing/WindowUrlPathChangeProviderTest.scala
@@ -14,9 +14,9 @@ class WindowUrlPathChangeProviderTest extends AsyncUdashFrontendTest {
       val originalFragment = provider.currentFragment
       val fragment = "lol"
 
-      provider.changeFragment(Url(fragment), replaceCurrent = false)
+      provider.changeFragment(fragment, replaceCurrent = false)
 
-      provider.currentFragment.value should endWith(s"/$fragment")
+      provider.currentFragment should endWith(s"/$fragment")
       dom.window.location.pathname should endWith(s"/$fragment")
       retrying {
         //sometimes history takes time to catch up here
@@ -35,10 +35,10 @@ class WindowUrlPathChangeProviderTest extends AsyncUdashFrontendTest {
       val historyLength = dom.window.history.length
       val fragment = "lol"
 
-      provider.changeFragment(Url(fragment), replaceCurrent = true)
+      provider.changeFragment(fragment, replaceCurrent = true)
 
       retrying {
-        provider.currentFragment.value should endWith(s"/$fragment")
+        provider.currentFragment should endWith(s"/$fragment")
         dom.window.location.pathname should endWith(s"/$fragment")
         dom.window.history.length shouldBe historyLength
       }

--- a/core/.js/src/test/scala/io/udash/testing/TestRoutingRegistry.scala
+++ b/core/.js/src/test/scala/io/udash/testing/TestRoutingRegistry.scala
@@ -13,7 +13,7 @@ class TestRoutingRegistry extends RoutingRegistry[TestState] {
 
   override def matchUrl(url: Url): TestState = {
     urlsHistory.append(url)
-    url.value match {
+    url match {
       case "/" => ObjectState
       case "/root" => RootState(None)
       case "/root" / v => RootState(Some(v.toInt))
@@ -26,7 +26,7 @@ class TestRoutingRegistry extends RoutingRegistry[TestState] {
 
   override def matchState(state: TestState): Url = {
     statesHistory.append(state)
-    Url(state match {
+    state match {
       case ObjectState => "/"
       case RootState(None) => "/root"
       case RootState(Some(v)) => s"/root/$v"
@@ -34,6 +34,6 @@ class TestRoutingRegistry extends RoutingRegistry[TestState] {
       case NextObjectState => "/next"
       case ClassState(arg, arg2) => s"/$arg/$arg2"
       case _ => ""
-    })
+    }
   }
 }

--- a/core/.js/src/test/scala/io/udash/testing/TestUrlChangeProvider.scala
+++ b/core/.js/src/test/scala/io/udash/testing/TestUrlChangeProvider.scala
@@ -19,7 +19,7 @@ class TestUrlChangeProvider(init: Url) extends UrlChangeProvider {
     changeListeners.foreach(_(url))
   }
 
-  override def changeUrl(url: String): Unit = changeFragment(Url(url))
+  override def changeUrl(url: String): Unit = changeFragment(url)
 
   override def currentFragment: Url = currUrl
 

--- a/guide/guide/.js/src/main/scala/io/udash/web/guide/RoutingRegistryDef.scala
+++ b/guide/guide/.js/src/main/scala/io/udash/web/guide/RoutingRegistryDef.scala
@@ -4,12 +4,12 @@ import io.udash._
 
 class RoutingRegistryDef extends RoutingRegistry[RoutingState] {
   def matchUrl(url: Url): RoutingState = {
-    val stripped = url.value.stripPrefix("/").stripSuffix("/")
+    val stripped = url.stripPrefix("/").stripSuffix("/")
     url2State.applyOrElse("/" + stripped, (_: String) => ErrorState)
   }
 
   def matchState(state: RoutingState): Url =
-    Url(state2Url.apply(state))
+    state2Url.apply(state)
 
   private val (url2State, state2Url) = bidirectional {
     case "/" => IntroState

--- a/guide/guide/.js/src/main/scala/io/udash/web/guide/RoutingStatesDef.scala
+++ b/guide/guide/.js/src/main/scala/io/udash/web/guide/RoutingStatesDef.scala
@@ -7,8 +7,8 @@ import io.udash.web.guide.markdown.MarkdownPage
 sealed abstract class RoutingState(val parentState: Option[ContainerRoutingState]) extends State {
   override type HierarchyRoot = RoutingState
 
-  def url(implicit application: Application[RoutingState]): String =
-    s"${application.matchState(this).value}"
+  def url(implicit application: Application[RoutingState]): Url =
+    s"${application.matchState(this)}"
 }
 sealed abstract class ContainerRoutingState(parentState: Option[ContainerRoutingState]) extends RoutingState(parentState)
 sealed abstract class MarkdownState(final val page: MarkdownPage) extends RoutingState(Some(ContentState)) with MarkdownPageState

--- a/guide/guide/.js/src/main/scala/io/udash/web/guide/views/ext/demo/bootstrap/BreadcrumbsDemo.scala
+++ b/guide/guide/.js/src/main/scala/io/udash/web/guide/views/ext/demo/bootstrap/BreadcrumbsDemo.scala
@@ -15,10 +15,10 @@ object BreadcrumbsDemo extends AutoDemo with CssView {
     import scalatags.JsDom.all._
 
     val pages = SeqProperty[Breadcrumb](
-      new Breadcrumb("Udash", Url("https://udash.io/")),
-      new Breadcrumb("Dev's Guide", Url("https://guide.udash.io/")),
-      new Breadcrumb("Extensions", Url("https://guide.udash.io/")),
-      new Breadcrumb("Bootstrap wrapper", Url("https://guide.udash.io/ext/bootstrap"))
+      new Breadcrumb("Udash", "https://udash.io/"),
+      new Breadcrumb("Dev's Guide", "https://guide.udash.io/"),
+      new Breadcrumb("Extensions", "https://guide.udash.io/"),
+      new Breadcrumb("Bootstrap wrapper", "https://guide.udash.io/ext/bootstrap")
     ).readable
 
     div(

--- a/guide/guide/.js/src/main/scala/io/udash/web/guide/views/ext/demo/bootstrap/ButtonDropdownDemo.scala
+++ b/guide/guide/.js/src/main/scala/io/udash/web/guide/views/ext/demo/bootstrap/ButtonDropdownDemo.scala
@@ -20,9 +20,9 @@ object ButtonDropdownDemo extends AutoDemo with CssView {
 
     val items = SeqProperty[DefaultDropdownItem](
       DefaultDropdownItem.Header("Start"),
-      DefaultDropdownItem.Link("Intro", Url(IntroState.url)),
+      DefaultDropdownItem.Link("Intro", IntroState.url),
       DefaultDropdownItem.Disabled(
-        DefaultDropdownItem.Link("Test Disabled", Url(BootstrapExtState.url))
+        DefaultDropdownItem.Link("Test Disabled", BootstrapExtState.url)
       ),
       DefaultDropdownItem.Divider,
       DefaultDropdownItem.Header("End"),

--- a/guide/guide/.js/src/main/scala/io/udash/web/guide/views/ext/demo/bootstrap/CarouselDemo.scala
+++ b/guide/guide/.js/src/main/scala/io/udash/web/guide/views/ext/demo/bootstrap/CarouselDemo.scala
@@ -24,7 +24,7 @@ object CarouselDemo extends AutoDemo with CssView {
 
     def newSlide(): UdashCarouselSlide = {
       UdashCarouselSlide(
-        Url("/assets/images/ext/bootstrap/carousel.jpg")
+        "/assets/images/ext/bootstrap/carousel.jpg"
       )(
         h3(randomString()),
         p(randomString())

--- a/guide/guide/.js/src/main/scala/io/udash/web/guide/views/ext/demo/bootstrap/DropdownsDemo.scala
+++ b/guide/guide/.js/src/main/scala/io/udash/web/guide/views/ext/demo/bootstrap/DropdownsDemo.scala
@@ -19,10 +19,10 @@ object DropdownsDemo extends AutoDemo with CrossLogging {
     import org.scalajs.dom.window
     import scalatags.JsDom.all._
 
-    val url = Url(BootstrapExtState.url)
+    val url = BootstrapExtState.url
     val items = SeqProperty[UdashDropdown.DefaultDropdownItem](Seq(
       UdashDropdown.DefaultDropdownItem.Header("Start"),
-      UdashDropdown.DefaultDropdownItem.Link("Intro", Url(IntroState.url)),
+      UdashDropdown.DefaultDropdownItem.Link("Intro", IntroState.url),
       UdashDropdown.DefaultDropdownItem.Disabled(
         UdashDropdown.DefaultDropdownItem.Link("Test Disabled", url)
       ),

--- a/guide/guide/.js/src/main/scala/io/udash/web/guide/views/frontend/FrontendRoutingView.scala
+++ b/guide/guide/.js/src/main/scala/io/udash/web/guide/views/frontend/FrontendRoutingView.scala
@@ -15,19 +15,19 @@ import scala.scalajs.js
 
 case object FrontendRoutingViewFactory extends ViewFactory[FrontendRoutingState] {
   override def create(): (View, Presenter[FrontendRoutingState]) = {
-    val url = Property.blank[String]
+    val url = Property.blank[Url]
     (new FrontendRoutingView(url), new FrontendRoutingPresenter(url))
   }
 }
 
-class FrontendRoutingPresenter(url: Property[String]) extends Presenter[FrontendRoutingState] {
+class FrontendRoutingPresenter(url: Property[Url]) extends Presenter[FrontendRoutingState] {
   import Context.applicationInstance
   override def handleState(state: FrontendRoutingState) = {
-    url.set(applicationInstance.currentUrl.value)
+    url.set(applicationInstance.currentUrl)
   }
 }
 
-class FrontendRoutingView(url: Property[String]) extends View with CssView {
+class FrontendRoutingView(url: Property[Url]) extends View with CssView {
   import Context._
   import JsDom.all._
 
@@ -191,7 +191,7 @@ class FrontendRoutingView(url: Property[String]) extends View with CssView {
             true
           })
         )),
-        p("This view was created with: ", span(id := "url-demo-link-init")(applicationInstance.currentUrl.value))
+        p("This view was created with: ", span(id := "url-demo-link-init")(applicationInstance.currentUrl))
       )
     ),
     h3("Handling routing errors"),

--- a/guide/homepage/.js/src/main/scala/io/udash/web/homepage/RoutingRegistryDef.scala
+++ b/guide/homepage/.js/src/main/scala/io/udash/web/homepage/RoutingRegistryDef.scala
@@ -4,10 +4,10 @@ import io.udash._
 
 class RoutingRegistryDef extends RoutingRegistry[RoutingState] {
   def matchUrl(url: Url): RoutingState =
-    url2State.applyOrElse("/" + url.value.stripPrefix("/").stripSuffix("/"), (_: String) => ErrorState)
+    url2State.applyOrElse("/" + url.stripPrefix("/").stripSuffix("/"), (_: String) => ErrorState)
 
   def matchState(state: RoutingState): Url =
-    Url(state2Url.apply(state))
+    state2Url.apply(state)
 
   private val (url2State, state2Url) = bidirectional {
     case "/" => IndexState(None)

--- a/guide/homepage/.js/src/main/scala/io/udash/web/homepage/states.scala
+++ b/guide/homepage/.js/src/main/scala/io/udash/web/homepage/states.scala
@@ -4,7 +4,7 @@ import io.udash._
 
 sealed abstract class RoutingState(val parentState: Option[ContainerRoutingState]) extends State {
   override type HierarchyRoot = RoutingState
-  def url(implicit application: Application[RoutingState]): String = s"${application.matchState(this).value}"
+  def url(implicit application: Application[RoutingState]): Url = s"${application.matchState(this)}"
 }
 sealed abstract class ContainerRoutingState(parentState: Option[ContainerRoutingState]) extends RoutingState(parentState)
 


### PR DESCRIPTION
This case class was since beginng of udash: 7c3176f9b7be419b000546864abf9ca7b42046a4 and had interesting remark: `Url wrapper - just for omitting strings.`

This case class hasn't got anything else except string, and all it forces developer to run a lot of `.value` and `Url(...)`.

Let remove it and simplify api!