### PR TITLE
Switch to use `Url` at `redirectTo` and `changeUrl`

### DIFF
--- a/core/.js/src/main/scala/io/udash/Application.scala
+++ b/core/.js/src/main/scala/io/udash/Application.scala
@@ -72,7 +72,7 @@ class Application[HierarchyRoot >: Null <: GState[HierarchyRoot] : PropertyCreat
   }
 
   /** Redirects to selected URL. */
-  def redirectTo(url: String): Unit =
+  def redirectTo(url: Url): Unit =
     urlChangeProvider.changeUrl(url)
 
   /**

--- a/core/.js/src/main/scala/io/udash/routing/UrlChangeProvider.scala
+++ b/core/.js/src/main/scala/io/udash/routing/UrlChangeProvider.scala
@@ -26,7 +26,7 @@ trait UrlChangeProvider {
   def onFragmentChange(callback: Url => Unit): Registration
 
   /** Changes the whole URL. */
-  def changeUrl(url: String): Unit = dom.window.location.assign(url)
+  def changeUrl(url: Url): Unit = dom.window.location.assign(url.value)
 }
 
 /** Used for routing based on the URL part following # sign. */

--- a/core/.js/src/test/scala/io/udash/ApplicationTest.scala
+++ b/core/.js/src/test/scala/io/udash/ApplicationTest.scala
@@ -30,7 +30,7 @@ class ApplicationTest extends UdashFrontendTest with TestRouting {
     }
 
     "redirect to URL" in {
-      app.redirectTo("http://www.avsystem.com/")
+      app.redirectTo(Url("http://www.avsystem.com/"))
       urlProvider.currUrl.value should be("http://www.avsystem.com/")
     }
 

--- a/core/.js/src/test/scala/io/udash/testing/TestUrlChangeProvider.scala
+++ b/core/.js/src/test/scala/io/udash/testing/TestUrlChangeProvider.scala
@@ -19,7 +19,7 @@ class TestUrlChangeProvider(init: Url) extends UrlChangeProvider {
     changeListeners.foreach(_(url))
   }
 
-  override def changeUrl(url: String): Unit = changeFragment(Url(url))
+  override def changeUrl(url: Url): Unit = changeFragment(url)
 
   override def currentFragment: Url = currUrl
 


### PR DESCRIPTION
It looks confusing now because `Application.currentUrl` returns `Url` when `Application.redirectTo(url)` expects `String`.

As result end user should make something like this
```
val urlBefore = application.currentUrl
//some magic here
application.redirectTo(urlBefore.value)
```

And this use case and this `.value` was a cause for https://github.com/UdashFramework/udash-core/pull/662