### PR TITLE
This is extention of unit test to catch a bug

### DIFF
--- a/core/src/test/scala/io/udash/properties/PropertyTest.scala
+++ b/core/src/test/scala/io/udash/properties/PropertyTest.scala
@@ -950,6 +950,18 @@ class PropertyTest extends UdashCoreTest {
       lastPatch.removed.size should be(3)
       elementsUpdated should be(0)
 
+      p.set("-1,-2,-3")
+
+      lastValue = null
+      lastPatch = null
+      elementsUpdated = 0
+      s.replace(1, 1, 2)
+      p.get should be("-1,2,-3")
+      lastValue should be(s.get)
+      lastPatch.added.size should be(0)
+      lastPatch.removed.size should be(0)
+      elementsUpdated should be(1)
+
       s.set(Seq(1, 0, 1, 0, 1))
       p.get should be("1,0,1,0,1")
 


### PR DESCRIPTION
Let assume that we have a `Property` that we is converted to `SeqPropery` via `bitransformToSeq`.

When something is calling `replace()` and this replace do not add or remove any element, and just replace it, well test is crashed like that:
```
[info] - should transform to SeqProperty *** FAILED ***
[info]   scala.scalajs.js.JavaScriptException: TypeError: $as_Lio_udash_properties_seq_Patch(...) is null
[info]   at $c_Lio_udash_properties_PropertyTest/right$90</</</<(file:///Users/catap/Documents/OpenSource/udash-core/core/.js/target/scala-2.13/udash-core-test-fastopt.js:114428:60)
[info]   at apply__O(file:///Users/catap/Documents/OpenSource/udash-core/core/.js/target/scala-2.13/udash-core-test-fastopt.js:47101:45)
[info]   at org.scalatest.OutcomeOf.outcomeOf(file:///Users/catap/Documents/OpenSource/udash-core/core/.js/target/scala-2.13/udash-core-test-fastopt.js:10388:7)
[info]   at apply__O(file:///Users/catap/Documents/OpenSource/udash-core/core/.js/target/scala-2.13/udash-core-test-fastopt.js:63507:12)
[info]   at apply__Lorg_scalatest_Outcome(file:///Users/catap/Documents/OpenSource/udash-core/core/.js/target/scala-2.13/udash-core-test-fastopt.js:55933:160)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.invokeWithFixture$1(file:///Users/catap/Documents/OpenSource/udash-core/core/.js/target/scala-2.13/udash-core-test-fastopt.js:93368:15)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.runTest(file:///Users/catap/Documents/OpenSource/udash-core/core/.js/target/scala-2.13/udash-core-test-fastopt.js:93711:153)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.runTests(file:///Users/catap/Documents/OpenSource/udash-core/core/.js/target/scala-2.13/udash-core-test-fastopt.js:93830:12)
[info]   at apply__O__O__O(file:///Users/catap/Documents/OpenSource/udash-core/core/.js/target/scala-2.13/udash-core-test-fastopt.js:47139:45)
[info]   at org.scalatest.SuperEngine.traverseSubNodes$1(file:///Users/catap/Documents/OpenSource/udash-core/core/.js/target/scala-2.13/udash-core-test-fastopt.js:11378:36)
[info]   ...
```

Original context: I've tried to use `FileInput.single(model.subProp(_.file))` where model's field `file` is initialized by default with `null` value.

This way do not allow to track changes at this file by
```
    FileInput.single(model.subProp(_.file))("file"),
    ul(
      showIf(model.subProp(_.file).transform(_ != null))(
        li(model.subProp(_.file).get.name).render
      )
    ),
```

I've tried to replace `showIf` to `showIfElse` like that
```
    FileInput.single(model.subProp(_.file))("file"),
    ul(
      showIf(model.subProp(_.file).transform(_ != null))(
        li(model.subProp(_.file).get.name).render,
        li("!!!").render
      )
    )
```

and `!!!` never appears => I've started to digg and created this test case.

Now I have no idea how to fix it.