### PR TITLE
Test fix

### DIFF
--- a/guide/selenium/src/test/scala/io/udash/web/guide/demos/rpc/RpcSerializationTest.scala
+++ b/guide/selenium/src/test/scala/io/udash/web/guide/demos/rpc/RpcSerializationTest.scala
@@ -12,16 +12,18 @@ class RpcSerializationTest extends SeleniumTest {
       callDemo.isEnabled should be(true)
       callDemo.click()
 
-      findElementById("gencodec-demo-int").getText shouldNot be(empty)
-      findElementById("gencodec-demo-double").getText shouldNot be(empty)
-      findElementById("gencodec-demo-string").getText shouldNot be(empty)
-      findElementById("gencodec-demo-seq").getText shouldNot be(empty)
-      findElementById("gencodec-demo-map").getText shouldNot be(empty)
-      findElementById("gencodec-demo-caseClass").getText shouldNot be(empty)
-      findElementById("gencodec-demo-cls-int").getText shouldNot be(empty)
-      findElementById("gencodec-demo-cls-string").getText shouldNot be(empty)
-      findElementById("gencodec-demo-cls-var").getText shouldNot be(empty)
-      findElementById("gencodec-demo-sealedTrait").getText shouldNot be(empty)
+      eventually {
+        findElementById("gencodec-demo-int").getText shouldNot be(empty)
+        findElementById("gencodec-demo-double").getText shouldNot be(empty)
+        findElementById("gencodec-demo-string").getText shouldNot be(empty)
+        findElementById("gencodec-demo-seq").getText shouldNot be(empty)
+        findElementById("gencodec-demo-map").getText shouldNot be(empty)
+        findElementById("gencodec-demo-caseClass").getText shouldNot be(empty)
+        findElementById("gencodec-demo-cls-int").getText shouldNot be(empty)
+        findElementById("gencodec-demo-cls-string").getText shouldNot be(empty)
+        findElementById("gencodec-demo-cls-var").getText shouldNot be(empty)
+        findElementById("gencodec-demo-sealedTrait").getText shouldNot be(empty)
+      }
     }
   }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ libraryDependencies += "org.scala-js" %% "scalajs-env-selenium" % "1.1.0"
 libraryDependencies += "org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.1.0"
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.3.0")
-addSbtPlugin("org.scala-js" % "sbt-jsdependencies" % "1.0.0")
+addSbtPlugin("org.scala-js" % "sbt-jsdependencies" % "1.0.2")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.1")
 addSbtPlugin("org.jetbrains" % "sbt-ide-settings" % "1.1.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.2")


### PR DESCRIPTION
There were 2 types of failures in `RpcSerializationTest`:
- empty text when element was found before RPC call was handled
- `StaleElementReferenceException` when element found by ID was rerendered already

Added top-level `eventually` block and updated `sbt-jsdependencies` to match `scalajs-env-selenium` (which introduced some differences in module handling).