### PR TITLE
Remove ReadableProperty#readable

### DIFF
--- a/bootstrap4/.js/src/main/scala/io/udash/bootstrap/alert/DismissibleUdashAlert.scala
+++ b/bootstrap4/.js/src/main/scala/io/udash/bootstrap/alert/DismissibleUdashAlert.scala
@@ -16,7 +16,7 @@ final class DismissibleUdashAlert private[alert](
   private val _dismissed = Property[Boolean](false)
 
   def dismissed: ReadableProperty[Boolean] =
-    _dismissed.readable
+    _dismissed
 
   private val button = UdashButton(buttonStyle = BootstrapStyles.Color.Link.toProperty) { _ => Seq[Modifier](
     componentId.withSuffix("close"),

--- a/core/.js/src/main/scala/io/udash/routing/RoutingEngine.scala
+++ b/core/.js/src/main/scala/io/udash/routing/RoutingEngine.scala
@@ -108,7 +108,7 @@ private[udash] final class RoutingEngine[HierarchyRoot >: Null <: GState[Hierarc
   def currentState: HierarchyRoot = currentStateProp.get
 
   /** @return Property reflecting current routing state */
-  def currentStateProperty: ReadableProperty[HierarchyRoot] = currentStateProp.readable
+  def currentStateProperty: ReadableProperty[HierarchyRoot] = currentStateProp
 
   @tailrec
   private def getStatePath(forState: Option[HierarchyRoot], acc: List[HierarchyRoot] = Nil): List[HierarchyRoot] = forState match {

--- a/core/src/main/scala/io/udash/properties/ImmutableProperty.scala
+++ b/core/src/main/scala/io/udash/properties/ImmutableProperty.scala
@@ -39,7 +39,6 @@ private[properties] class ImmutableProperty[A](value: A) extends ReadablePropert
     ImmutableProperty.NoOpRegistration
   }
 
-  override final def readable: this.type = this
 }
 
 private[properties] final class ImmutableModelProperty[A](value: A)

--- a/core/src/main/scala/io/udash/properties/model/ModelProperty.scala
+++ b/core/src/main/scala/io/udash/properties/model/ModelProperty.scala
@@ -32,6 +32,5 @@ trait ModelProperty[A] extends AbstractProperty[A] with ModelPropertyMacroApi[A]
     implicit ev: SeqPropertyCreator[B, SeqTpe]
   ): SeqProperty[B, CastableProperty[B]] = macro io.udash.macros.PropertyMacros.reifySubSeq[A, B, SeqTpe]
 
-  override def readable: ModelProperty[A] = this
 }
 

--- a/core/src/main/scala/io/udash/properties/model/ReadableModelProperty.scala
+++ b/core/src/main/scala/io/udash/properties/model/ReadableModelProperty.scala
@@ -19,9 +19,6 @@ trait ReadableModelProperty[+A] extends ReadableProperty[A] {
   /** Returns child DirectSeqProperty[B] */
   def roSubSeq[B, SeqTpe[T] <: BSeq[T]](f: A => SeqTpe[B])(implicit ev: SeqPropertyCreator[B, SeqTpe]): ReadableSeqProperty[B, CastableReadableProperty[B]] =
     macro io.udash.macros.PropertyMacros.reifyRoSubSeq[A, B]
-
-  /** Ensures read-only access to this property. */
-  override def readable: ReadableModelProperty[A]
 }
 
 trait ModelPropertyMacroApi[A] extends ReadableModelProperty[A] {

--- a/core/src/main/scala/io/udash/properties/seq/PropertySeqCombinedReadableSeqProperty.scala
+++ b/core/src/main/scala/io/udash/properties/seq/PropertySeqCombinedReadableSeqProperty.scala
@@ -10,7 +10,6 @@ private[properties] class PropertySeqCombinedReadableSeqProperty[A](value: ISeq[
 
   override protected[properties] val parent: ReadableProperty[_] = null
 
-  private val children = value.map(_.readable)
   private var originListenerRegistration: Registration = _
 
   private def killOriginListeners(): Unit = {
@@ -66,10 +65,10 @@ private[properties] class PropertySeqCombinedReadableSeqProperty[A](value: ISeq[
   }
 
   override def get: ISeq[A] =
-    children.map(_.get)
+    value.map(_.get)
 
   override def elemProperties: ISeq[ReadableProperty[A]] =
-    children
+    value
 
   override def listenStructure(structureListener: Patch[ReadableProperty[A]] => Any): Registration =
     ImmutableProperty.NoOpRegistration

--- a/core/src/main/scala/io/udash/properties/seq/ReadableSeqProperty.scala
+++ b/core/src/main/scala/io/udash/properties/seq/ReadableSeqProperty.scala
@@ -66,8 +66,6 @@ trait ReadableSeqProperty[+A, +ElemType <: ReadableProperty[A]] extends Readable
 
   /** Zips elements from `this` SeqProperty with their indexes. */
   def zipWithIndex: ReadableSeqProperty[(A, Int), ReadableProperty[(A, Int)]]
-
-  override def readable: ReadableSeqProperty[A, ReadableProperty[A]]
 }
 
 private[properties] trait AbstractReadableSeqProperty[A, ElemType <: ReadableProperty[A]]
@@ -107,5 +105,4 @@ private[properties] trait AbstractReadableSeqProperty[A, ElemType <: ReadablePro
     )
   }
 
-  override def readable: ReadableSeqProperty[A, ReadableProperty[A]] = this
 }

--- a/core/src/main/scala/io/udash/properties/seq/SeqPropertyFromSingleValue.scala
+++ b/core/src/main/scala/io/udash/properties/seq/SeqPropertyFromSingleValue.scala
@@ -138,8 +138,7 @@ private[properties] final class ReadableSeqPropertyFromSingleValue[A, B: Propert
   origin: ReadableProperty[A], transformer: A => BSeq[B]
 ) extends BaseReadableSeqPropertyFromSingleValue[A, B, ReadableProperty[B]](origin, transformer, listenChildren = false) {
 
-  override protected def toElemProp(p: Property[B]): ReadableProperty[B] =
-    p.readable
+  override protected def toElemProp(p: Property[B]): ReadableProperty[B] = p
 }
 
 private[properties] final class SeqPropertyFromSingleValue[A, B: PropertyCreator](

--- a/core/src/main/scala/io/udash/properties/single/ReadableProperty.scala
+++ b/core/src/main/scala/io/udash/properties/single/ReadableProperty.scala
@@ -24,9 +24,6 @@ trait ReadableProperty[+A] {
   /** Returns listeners count. */
   def listenersCount(): Int
 
-  /** Read-only interface of this property. */
-  def readable: ReadableProperty[A]
-
   /** This method should be called when the value has changed. */
   protected[properties] def valueChanged(): Unit
 
@@ -103,8 +100,6 @@ private[properties] trait AbstractReadableProperty[A] extends ReadableProperty[A
   override protected[properties] def listenersUpdate(): Unit = {
     if (parent != null) parent.listenersUpdate()
   }
-
-  override def readable: ReadableProperty[A] = this
 
   override def transform[B](transformer: A => B): ReadableProperty[B] =
     new TransformedReadableProperty[A, B](this, transformer)

--- a/guide/guide/.js/src/main/scala/io/udash/web/guide/views/ext/demo/bootstrap/BreadcrumbsDemo.scala
+++ b/guide/guide/.js/src/main/scala/io/udash/web/guide/views/ext/demo/bootstrap/BreadcrumbsDemo.scala
@@ -19,7 +19,7 @@ object BreadcrumbsDemo extends AutoDemo with CssView {
       new Breadcrumb("Dev's Guide", Url("https://guide.udash.io/")),
       new Breadcrumb("Extensions", Url("https://guide.udash.io/")),
       new Breadcrumb("Bootstrap wrapper", Url("https://guide.udash.io/ext/bootstrap"))
-    ).readable
+    )
 
     div(
       UdashBreadcrumbs(pages)(

--- a/guide/guide/.js/src/main/scala/io/udash/web/guide/views/frontend/FrontendPropertiesView.scala
+++ b/guide/guide/.js/src/main/scala/io/udash/web/guide/views/frontend/FrontendPropertiesView.scala
@@ -321,15 +321,6 @@ class FrontendPropertiesView extends View with CssView {
         |strings.clear()
         |// withIdx.get == Seq()""".stripMargin
     )(GuideStyles),
-    h4("Ensuring readonly access"),
-    p(
-      "When you expose a property and you want to ensure that the exposed reference enables only the read access ",
-      "use the ", i("_.readable"), " method which does not allow to modify the property by type casting. "
-    ),
-    CodeBlock(
-      """val p: Property[Int] = Property(0)
-        |val ro: ReadableProperty[Int] = p.readable""".stripMargin
-    )(GuideStyles),
     h3("Immutable properties"),
     p(
       "GUI components may take numerous arguments defining their behaviour as the properties. ",


### PR DESCRIPTION
Now that RPs are covariant, this method seems largely redundant. It no longer prevents pattern matching and mutating properties anyway.