### PR TITLE
API proposal: ReadableProperty#mirror

### DIFF
--- a/core/src/main/scala/io/udash/properties/single/ReadableProperty.scala
+++ b/core/src/main/scala/io/udash/properties/single/ReadableProperty.scala
@@ -74,7 +74,7 @@ trait ReadableProperty[+A] {
     new CombinedProperty[A, B, O](this, property, combiner)
 }
 
-final class MirrorProperty[B](origin: ReadableProperty[B]) {
+final class MirrorProperty[B: PropertyCreator](origin: ReadableProperty[B]) {
   private val castable: CastableProperty[B] = PropertyCreator[B].newProperty(origin.get, null)
   private val registration = origin.streamTo(castable, initUpdate = false)(identity)
   def cancel(): Unit = registration.cancel()

--- a/core/src/main/scala/io/udash/properties/single/ReadableProperty.scala
+++ b/core/src/main/scala/io/udash/properties/single/ReadableProperty.scala
@@ -74,13 +74,12 @@ trait ReadableProperty[+A] {
     new CombinedProperty[A, B, O](this, property, combiner)
 }
 
-final class MirrorProperty[B: PropertyCreator](origin: ReadableProperty[B]) {
-  private val castable: CastableProperty[B] = PropertyCreator[B].newProperty(origin.get, null)
+final class MirrorProperty[A: PropertyCreator](origin: ReadableProperty[A]) {
+  private val castable: CastableProperty[A] = PropertyCreator[A].newProperty(origin.get, null)
   private val registration = origin.streamTo(castable, initUpdate = false)(identity)
-  def cancel(): Unit = registration.cancel()
 }
 object MirrorProperty {
-  implicit def castable[B](property: MirrorProperty[B]): CastableProperty[B] = property.castable
+  implicit def castable[A](property: MirrorProperty[A]): CastableProperty[A] = property.castable
   implicit def registration(property: MirrorProperty[_]): Registration = property.registration
 }
 

--- a/core/src/main/scala/io/udash/properties/single/ReadableProperty.scala
+++ b/core/src/main/scala/io/udash/properties/single/ReadableProperty.scala
@@ -55,6 +55,9 @@ trait ReadableProperty[+A] {
    * It is not as strong relation as `transform`, because `target` can change value independently. */
   def streamTo[B](target: Property[B], initUpdate: Boolean = true)(transformer: A => B): Registration
 
+  def mirror[B >: A : PropertyCreator](): CastableProperty[B] =
+    PropertyCreator[B].newProperty(get, null).setup(streamTo(_, initUpdate = false)(identity))
+
   /**
    * Combines two properties into a new one. Created property will be updated after any change in the origin ones.
    *

--- a/core/src/main/scala/io/udash/properties/single/ReadableProperty.scala
+++ b/core/src/main/scala/io/udash/properties/single/ReadableProperty.scala
@@ -51,10 +51,16 @@ trait ReadableProperty[+A] {
    */
   def transformToSeq[B: PropertyCreator](transformer: A => BSeq[B]): ReadableSeqProperty[B, ReadableProperty[B]]
 
-  /** Streams value changes to the `target` property.
-   * It is not as strong relation as `transform`, because `target` can change value independently. */
+  /**
+   * Streams value changes to the `target` property.
+   * It is not as strong relation as `transform`, because `target` can change value independently.
+   */
   def streamTo[B](target: Property[B], initUpdate: Boolean = true)(transformer: A => B): Registration
 
+  /**
+   * Creates a mutable copy of this property which follows the stream of updates from this property.
+   * Similarly to [[streamTo]], the target can change value independently and origin value updates can be cancelled.
+   */
   def mirror[B >: A : PropertyCreator](): MirrorProperty[B] =
     new MirrorProperty(this)
 

--- a/core/src/test/scala/io/udash/properties/ImmutablePropertyTest.scala
+++ b/core/src/test/scala/io/udash/properties/ImmutablePropertyTest.scala
@@ -1,7 +1,7 @@
 package io.udash.properties
 
-import io.udash.properties.model.ReadableModelProperty
-import io.udash.properties.seq.ReadableSeqProperty
+import io.udash.properties.model.{ModelProperty, ReadableModelProperty}
+import io.udash.properties.seq.{ReadableSeqProperty, SeqProperty}
 import io.udash.properties.single.{Property, ReadableProperty}
 import io.udash.testing.UdashCoreTest
 
@@ -25,6 +25,36 @@ class ImmutablePropertyTest extends UdashCoreTest {
       t.get should be(0)
       p.streamTo(t, initUpdate = true)(identity)
       t.get should be(7)
+    }
+
+    "support mirrors" in {
+      val origin = new ImmutableProperty[Int](7)
+      val p = origin.mirror()
+      p.get should be(7)
+
+      var counter = 0
+      val listener1 = p.listen(_ => counter += 1)
+      counter should be(0)
+      val listener2 = p.listen(_ => counter += 1, initUpdate = true)
+      counter should be(1)
+      listener1.cancel()
+      p.set(42)
+      counter should be(2)
+
+      val t = Property(0)
+      val listener3 = p.streamTo(t, initUpdate = false)(identity)
+      t.get should be(0)
+      val listener4 = p.streamTo(t, initUpdate = true)(identity)
+      t.get should be(42)
+      p.set(64)
+      t.get should be(64)
+
+      origin.get should be(7)
+      origin.listenersCount() should be(0)
+      p.listenersCount() should be(3)
+
+      Seq(listener2, listener3, listener4).foreach(_.cancel())
+      p.listenersCount() should be(0)
     }
   }
 
@@ -54,6 +84,28 @@ class ImmutablePropertyTest extends UdashCoreTest {
 
       p.roSubModel(_.s).roSubProp(_.s).get shouldBe null
     }
+
+    "support mirrors" in {
+      val e = ModelEntity("a", Seq(1), Vector(2, 3), ModelEntity("b", Seq(4), Vector(5, 6), ModelEntity("c", Seq(7), Vector(8, 9), null)))
+      val origin: ReadableModelProperty[ModelEntity] = new ImmutableModelProperty[ModelEntity](e)
+      val p: ModelProperty[ModelEntity] = origin.mirror().asModel
+
+      p.get shouldBe e
+      val subModel = p.subModel(_.m)
+      subModel.get shouldBe e.m
+      val subProp = subModel.subProp(_.s)
+      subProp.get shouldBe e.m.s
+      subProp.set("d")
+      subProp.get shouldBe "d"
+      p.get.m.s shouldBe "d"
+
+      val subSeq = p.subSeq(_.v)
+      subSeq.elemProperties.head.set(3)
+      subSeq.get shouldBe Seq(3,3)
+
+      origin.listenersCount() shouldBe 0
+      origin.get shouldBe e
+    }
   }
 
   "ImmutableSeqProperty" should {
@@ -71,6 +123,28 @@ class ImmutablePropertyTest extends UdashCoreTest {
       counter should be(1)
       p.listenStructure(_ => counter += 1)
       counter should be(1)
+    }
+
+    "support mirrors" in {
+      val origin = new ImmutableSeqProperty[Int, Seq](Seq(1, 2, 3))
+      val p: SeqProperty[Int, Property[Int]] = origin.mirror().asSeq
+
+      p.get should be(Seq(1,2,3))
+      p.elemProperties.map(_.get) should be(Seq(1,2,3))
+      p.transformElements(_ + 1).get should be(Seq(2, 3, 4))
+
+      var counter = 0
+      p.listen(_ => counter += 1)
+      counter should be(0)
+      p.listen(_ => counter += 1, initUpdate = true)
+      counter should be(1)
+      p.listenStructure(_ => counter += 1)
+      counter should be(1)
+
+      p.elemProperties.head.set(7)
+      p.get should be(Seq(7,2,3))
+      counter should be(3)
+      origin.listenersCount() should be(0)
     }
   }
 }

--- a/core/src/test/scala/io/udash/properties/PropertyTest.scala
+++ b/core/src/test/scala/io/udash/properties/PropertyTest.scala
@@ -1400,6 +1400,38 @@ class PropertyTest extends UdashCoreTest {
 
       p.get shouldBe SimpleSeq(Seq(SimpleSeq(Seq(SimpleSeq(Seq(SimpleSeq(Seq(), null)), null)), null)), null)
     }
+
+    "support mirroring" in {
+      val source = SeqProperty(1, 2, 3)
+      val transformed = source.transformElements(_ * 2)
+      val filtered = transformed.filter(_ < 10)
+      val sum = filtered.transform(_.sum)
+
+      println(source.listenersCount())
+
+      val target = sum.mirror()
+
+      println(source.listenersCount())
+
+      target.get should be(12)
+
+      source.append(4)
+      target.get should be(20)
+
+      source.touch()
+      target.get should be(20)
+
+      target.set(0)
+      target.get should be(0)
+
+      source.touch()
+      target.get should be(20)
+
+      source.remove(2)
+      target.get should be(16)
+
+      println(source.listenersCount())
+    }
   }
 }
 

--- a/core/src/test/scala/io/udash/properties/PropertyTest.scala
+++ b/core/src/test/scala/io/udash/properties/PropertyTest.scala
@@ -1407,11 +1407,7 @@ class PropertyTest extends UdashCoreTest {
       val filtered = transformed.filter(_ < 10)
       val sum = filtered.transform(_.sum)
 
-      println(source.listenersCount())
-
       val target = sum.mirror()
-
-      println(source.listenersCount())
 
       target.get should be(12)
 
@@ -1430,7 +1426,11 @@ class PropertyTest extends UdashCoreTest {
       source.remove(2)
       target.get should be(16)
 
-      println(source.listenersCount())
+      target.cancel()
+
+      source.append(2)
+      target.get should be(16)
+      source.listenersCount() shouldBe 0
     }
   }
 }


### PR DESCRIPTION
This is a pattern we've commonly seen in our codebases whenever a mutable `Property` is an argument to some component while we can only provide a unidirectional stream of updates. This is a draft - feel free to propose alternative approaches or straight out reject this ;)