### PR TITLE
guide: use openjdk11 as base image

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -466,6 +466,7 @@ lazy val `guide-packager` =
 
       dockerExposedPorts += 8080, //should match ui.server.port
       dockerEnvVars += "DISABLE_FILE_LOGGING" -> "true",
+      dockerBaseImage := "openjdk:11",
     )
 
 lazy val `guide-selenium` =


### PR DESCRIPTION
sbt-native-packager uses openjdk:8 as base image[^1] and OpenJDK8 can't run guide on it, and throw an exception like
```
Exception in thread "pool-1-thread-1" java.lang.NoSuchMethodError: java.io.FileReader.<init>(Ljava/io/File;Ljava/nio/charset/Charset;)V
	at io.udash.web.guide.markdown.MarkdownPagesEndpoint.$anonfun$render$1(MarkdownPagesEndpoint.scala:23)
	at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:671)
	at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:430)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

Fixed #709

[^1]: https://github.com/sbt/sbt-native-packager/blob/v1.7.6/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala#L85