### PR TITLE
Fix repeat init with empty SeqProperty

### DIFF
--- a/core/.js/src/main/scala/io/udash/bindings/modifiers/SeqPropertyModifierUtils.scala
+++ b/core/.js/src/main/scala/io/udash/bindings/modifiers/SeqPropertyModifierUtils.scala
@@ -97,6 +97,13 @@ private[bindings] trait SeqPropertyModifierUtils[T, E <: ReadableProperty[T]] ex
       if (firstElement == null) firstElement = els.head
       replace(root)(Seq.empty, els)
     }
+
+    if (firstElement == null) {
+      val el = emptyStringNode()
+      firstElement = el
+      replace(root)(Seq.empty, Seq(el))
+      firstElementIsPlaceholder = true
+    }
   }
 }
 

--- a/core/.js/src/test/scala/io/udash/bindings/TagsBindingTest.scala
+++ b/core/.js/src/test/scala/io/udash/bindings/TagsBindingTest.scala
@@ -1253,6 +1253,44 @@ class TagsBindingTest extends UdashFrontendTest with Bindings { bindings: Bindin
       template.childNodes(4).textContent should be("")
     }
 
+    "handle init with empty SeqProperty" in {
+      val p = seq.SeqProperty.blank[Int]
+      val template = div(
+        span(),
+        repeat(p)((p: Property[Int]) => {
+          val v = p.get
+          if (v % 2 == 0) b(v.toString).render
+          else i(v.toString).render
+        }),
+        span()
+      ).render
+
+      template.childNodes.length should be(3) // spans + placeholder
+      p.set(Seq(1,2,3))
+
+      template.childNodes.length should be(3 + 2)
+      template.childNodes(0).textContent should be("")
+      template.childNodes(1).nodeName should be("I")
+      template.childNodes(1).textContent should be("1")
+      template.childNodes(2).nodeName should be("B")
+      template.childNodes(2).textContent should be("2")
+      template.childNodes(3).nodeName should be("I")
+      template.childNodes(3).textContent should be("3")
+      template.childNodes(4).textContent should be("")
+
+      p.set(Seq())
+      template.childNodes.length should be(1 + 2)
+      template.childNodes(0).textContent should be("")
+      template.childNodes(1).textContent should be("")
+      template.childNodes(2).textContent should be("")
+
+      p.append(1)
+      template.childNodes.length should be(1 + 2)
+      template.childNodes(0).textContent should be("")
+      template.childNodes(1).textContent should be("1")
+      template.childNodes(2).textContent should be("")
+    }
+
     "handle Seq of produced elements" in {
       val p1 = SeqProperty[Int](1, 2, 3)
       val p2 = SeqProperty[Int](4, 5, 6)


### PR DESCRIPTION
Fixes a bug introduced in 1f752ae22d919b3fc4db85997462144b6be98e73. Since then `repeat` does not append any placeholder on init with empty `SeqProperty`. 

Could you publish an updated version ASAP? 