### PR TITLE
Fix "Key not found" error in `repeatWithIndex`

### DIFF
--- a/core/.js/src/main/scala/io/udash/bindings/modifiers/SeqPropertyWithIndexModifier.scala
+++ b/core/.js/src/main/scala/io/udash/bindings/modifiers/SeqPropertyWithIndexModifier.scala
@@ -14,7 +14,7 @@ private[bindings] final class SeqPropertyWithIndexModifier[T, E <: ReadablePrope
 
   private val indexes = MHashMap.empty[E, Property[Int]]
 
-  protected def indexProperty(p: E): ReadableProperty[Int] =
+  protected def indexProperty(p: E): Property[Int] =
     indexes.getOrElseUpdate(p, Property(property.elemProperties.indexOf(p).applyIf(_ == -1)(_ => 0)))
 
   override protected def build(item: E): Seq[Node] =
@@ -24,7 +24,7 @@ private[bindings] final class SeqPropertyWithIndexModifier[T, E <: ReadablePrope
     super.handlePatch(root)(patch)
     patch.removed.foreach(indexes.remove)
     property.elemProperties.zipWithIndex.drop(patch.idx).foreach { case (p, i) =>
-      indexes(p).set(i)
+      indexProperty(p).set(i)
     }
   }
 

--- a/core/.js/src/main/scala/io/udash/bindings/modifiers/SeqPropertyWithIndexModifier.scala
+++ b/core/.js/src/main/scala/io/udash/bindings/modifiers/SeqPropertyWithIndexModifier.scala
@@ -3,6 +3,7 @@ package io.udash.bindings.modifiers
 import com.avsystem.commons._
 import io.udash.properties.seq.{Patch, ReadableSeqProperty}
 import io.udash.properties.single.{Property, ReadableProperty}
+import io.udash.utils.CrossCollections
 import org.scalajs.dom._
 
 private[bindings] final class SeqPropertyWithIndexModifier[T, E <: ReadableProperty[T]](
@@ -12,9 +13,9 @@ private[bindings] final class SeqPropertyWithIndexModifier[T, E <: ReadablePrope
   override val customElementsInsert: DOMManipulator.InsertMethod
 ) extends SeqPropertyModifierUtils[T, E] {
 
-  private val indexes = MHashMap.empty[E, Property[Int]]
+  private val indexes = CrossCollections.createMap[E, Property[Int]]
 
-  protected def indexProperty(p: E): Property[Int] =
+  private def indexProperty(p: E): Property[Int] =
     indexes.getOrElseUpdate(p, Property(property.elemProperties.indexOf(p).applyIf(_ == -1)(_ => 0)))
 
   override protected def build(item: E): Seq[Node] =
@@ -23,7 +24,7 @@ private[bindings] final class SeqPropertyWithIndexModifier[T, E <: ReadablePrope
   override protected def handlePatch(root: Node)(patch: Patch[E]): Unit = {
     super.handlePatch(root)(patch)
     patch.removed.foreach(indexes.remove)
-    property.elemProperties.zipWithIndex.drop(patch.idx).foreach { case (p, i) =>
+    property.elemProperties.iterator.zipWithIndex.drop(patch.idx).foreach { case (p, i) =>
       indexProperty(p).set(i)
     }
   }

--- a/core/.js/src/test/scala/io/udash/bindings/TagsBindingTest.scala
+++ b/core/.js/src/test/scala/io/udash/bindings/TagsBindingTest.scala
@@ -1922,6 +1922,27 @@ class TagsBindingTest extends UdashFrontendTest with Bindings { bindings: Bindin
 
       p.replace(1, 2, "a", "B")
       el.textContent should be("0x1a2B")
+
+      p.set(Seq("q", "w", "e", "r"))
+      el.textContent should be("0q1w2e3r")
+
+      p.set(Seq("z", "x"))
+      el.textContent should be("0z1x")
+
+      p.set(Seq("q", "w", "e", "r"))
+      el.textContent should be("0q1w2e3r")
+
+      CallbackSequencer().sequence {
+        p.set(Seq())
+        p.set(Seq("c", "d"))
+      }
+      el.textContent should be("0c1d")
+
+      CallbackSequencer().sequence {
+        p.set(Seq("a", "b"))
+        p.set(Seq("x", "y"))
+      }
+      el.textContent should be("0x1y")
     }
 
     "set initial index values to corresponding elements' position in underlying SeqProperty" in {


### PR DESCRIPTION
Fix "Key not found" error in `repeatWithIndex` caused by updates batched in `CallbackSequencer`.

Reproduction in tests. 