### PR TITLE
Added optional Select input binding

### DIFF
--- a/core/.js/src/main/scala/io/udash/bindings/inputs/Select.scala
+++ b/core/.js/src/main/scala/io/udash/bindings/inputs/Select.scala
@@ -59,11 +59,8 @@ object Select {
     selectedItem: Property[Option[T]], options: ReadableSeqProperty[T], labelNoValue: Modifier
   )(label: T => Modifier, selectModifiers: Modifier*): InputBinding[Select] = {
     new SelectBinding(options, label, Some(labelNoValue), selectModifiers)(
-      opt => selectedItem.transform {
-        case None => false
-        case Some(si) => si == opt
-      },
-      opts => if (!opts.exists(x => selectedItem.get.contains(x))) selectedItem.set(None),
+      opt => selectedItem.transform(_.contains(opt)),
+      opts => if (selectedItem.get.isEmpty && !opts.exists(x => selectedItem.get.contains(x))) selectedItem.set(None),
       selector => (_: Event) => selector.value match {
         case ""  => selectedItem.set(None)
         case s:String =>  selectedItem.set(Some(options.get.apply(s.toInt)))

--- a/core/.js/src/main/scala/io/udash/bindings/inputs/SelectBinding.scala
+++ b/core/.js/src/main/scala/io/udash/bindings/inputs/SelectBinding.scala
@@ -6,7 +6,7 @@ import org.scalajs.dom.html.Select
 import scalatags.JsDom.all._
 
 private[inputs] class SelectBinding[T](
-  options: ReadableSeqProperty[T], label: T => Modifier, selectModifiers: Modifier*
+  options: ReadableSeqProperty[T], label: T => Modifier, labelNoValue:Option[Modifier], selectModifiers: Modifier*
 )(
   checkedIf: T => ReadableProperty[Boolean],
   refreshSelection: Seq[T] => Unit,
@@ -17,7 +17,11 @@ private[inputs] class SelectBinding[T](
       kill()
       refreshSelection(opts)
 
-      opts.zipWithIndex.map { case (opt, idx) =>
+      val empty = labelNoValue.map{ l =>
+        option(l, value := "").render
+      }.toSeq
+
+      empty ++ opts.zipWithIndex.map { case (opt, idx) =>
         val el = option(value := idx.toString, label(opt)).render
 
         val selected = checkedIf(opt)

--- a/core/.js/src/main/scala/io/udash/bindings/inputs/SelectBinding.scala
+++ b/core/.js/src/main/scala/io/udash/bindings/inputs/SelectBinding.scala
@@ -6,7 +6,7 @@ import org.scalajs.dom.html.Select
 import scalatags.JsDom.all._
 
 private[inputs] class SelectBinding[T](
-  options: ReadableSeqProperty[T], label: T => Modifier, labelNoValue:Option[Modifier], selectModifiers: Modifier*
+  options: ReadableSeqProperty[T], label: T => Modifier, labelNoValue: Option[Modifier], selectModifiers: Modifier*
 )(
   checkedIf: T => ReadableProperty[Boolean],
   refreshSelection: Seq[T] => Unit,
@@ -17,17 +17,19 @@ private[inputs] class SelectBinding[T](
       kill()
       refreshSelection(opts)
 
-      val empty = labelNoValue.map{ l =>
+      val empty = labelNoValue.map { l =>
         option(l, value := "").render
-      }.toSeq
-
-      empty ++ opts.zipWithIndex.map { case (opt, idx) =>
-        val el = option(value := idx.toString, label(opt)).render
-
-        val selected = checkedIf(opt)
-        propertyListeners += selected.listen(el.selected = _, initUpdate = true)
-        el
       }
+
+      {
+          empty.iterator ++ opts.iterator.zipWithIndex.map { case (opt, idx) =>
+            val el = option(value := idx.toString, label(opt)).render
+
+            val selected = checkedIf(opt)
+            propertyListeners += selected.listen(el.selected = _, initUpdate = true)
+            el
+          }
+      }.toSeq
     }
   ).render
 

--- a/core/.js/src/test/scala/io/udash/bindings/inputs/SelectTest.scala
+++ b/core/.js/src/test/scala/io/udash/bindings/inputs/SelectTest.scala
@@ -135,6 +135,18 @@ class SelectTest extends UdashFrontendTest {
       select.childElementCount should be(4) // empty value should be included
       select.value should be("1")
 
+      def trimHtml(s:String):String = s.split("\n").map(_.trim).mkString
+
+      val expectedHtml = """<select>
+                           |  <option value="">empty</option>
+                           |  <option value="0">A</option>
+                           |  <option value="1"></option>
+                           |  <option value="2">B</option>
+                           |</select>
+                           |""".stripMargin
+
+      trimHtml(select.outerHTML) should be(trimHtml(expectedHtml))
+
       p.set(None)
       select.value should be("")
 

--- a/core/.js/src/test/scala/io/udash/bindings/inputs/SelectTest.scala
+++ b/core/.js/src/test/scala/io/udash/bindings/inputs/SelectTest.scala
@@ -125,6 +125,25 @@ class SelectTest extends UdashFrontendTest {
       r.value should be("4")
       r2.value should be("1")
     }
+
+    "handle optional case" in {
+      val options = Seq(Some("A"), None, Some("B"))
+      val p = Property[Option[Option[String]]](Some(None))
+
+      val select = Select.optional(p, options.toSeqProperty,StringFrag("empty"))(x => StringFrag(x.getOrElse(""))).render
+
+      select.childElementCount should be(4) // empty value should be included
+      select.value should be("1")
+
+      p.set(None)
+      select.value should be("")
+
+      for ((o, idx) <- options.zipWithIndex) {
+        p.set(Some(o))
+        select.value should be(idx.toString)
+      }
+    }
+
   }
 
   "Select with multiple on" should {


### PR DESCRIPTION
First of all thank you very much for the great product. I'm a very happy udash user! And using it extensivly on my open source project https://github.com/Insubric/box

For my projects I'm using quite a lot the native HTML5 form validation, an in general with udash it works smoothly, I just come across a minor limitation on the select element, using `required` on the select element with the current implementation does not trigger any validation and we have no way to put a `null` option, but there are use cases where this is needed.
For reference see MDN select required documentation https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#attr-required.

In order to overcome this limitation my proposition is to add a `optional` method on `io.udash.bindings.inputs.Select` with that signature:
```
def optional[T](
    selectedItem: Property[Option[T]], options: ReadableSeqProperty[T], labelNoValue:Modifier
  )(label: T => Modifier, selectModifiers: Modifier*): InputBinding[Select]
```
basically is the same of the `apply` just the selectedItem is optional and we need a label when no value is selected.

The usage is pretty straightforward.

Thanks

Andrea

