### PR TITLE
BiDirection RPC

### DIFF
--- a/rpc/src/main/scala/io/udash/rpc/companions.scala
+++ b/rpc/src/main/scala/io/udash/rpc/companions.scala
@@ -14,6 +14,14 @@ trait ClientRpcInstances[T] {
   def asReal: ClientRawRpc.AsRealRpc[T]
 }
 
+trait BiDirectionRpcInstances[T] {
+  def asServerRaw: ServerRawRpc.AsRawRpc[T]
+  def asServerReal: ServerRawRpc.AsRealRpc[T]
+  def serverMetadata: ServerRpcMetadata[T]
+  def asClientRaw: ClientRawRpc.AsRawRpc[T]
+  def asClientReal: ClientRawRpc.AsRealRpc[T]
+}
+
 abstract class ServerRpcCompanion[Serialization, ServerRpc](serialization: Serialization)(
   implicit instances: MacroInstances[Serialization, ServerRpcInstances[ServerRpc]]
 ) {
@@ -29,6 +37,16 @@ abstract class ClientRpcCompanion[Serialization, ClientRpc](serialization: Seria
   implicit lazy val asReal: ClientRawRpc.AsRealRpc[ClientRpc] = instances(serialization, this).asReal
 }
 
+abstract class BiDirectionRpcCompanion[Serialization, BiDirectionRpc](serialization: Serialization)(
+  implicit instances: MacroInstances[Serialization, BiDirectionRpcInstances[BiDirectionRpc]]
+) {
+  implicit lazy val asServerRaw: ServerRawRpc.AsRawRpc[BiDirectionRpc] = instances(serialization, this).asServerRaw
+  implicit lazy val asServerReal: ServerRawRpc.AsRealRpc[BiDirectionRpc] = instances(serialization, this).asServerReal
+  implicit lazy val serverMetadata: ServerRpcMetadata[BiDirectionRpc] = instances(serialization, this).serverMetadata
+  implicit lazy val asClientRaw: ClientRawRpc.AsRawRpc[BiDirectionRpc] = instances(serialization, this).asClientRaw
+  implicit lazy val asClientReal: ClientRawRpc.AsRealRpc[BiDirectionRpc] = instances(serialization, this).asClientReal
+}
+
 abstract class DefaultServerRpcCompanion[ServerRpc](
   implicit instances: MacroInstances[DefaultUdashSerialization, ServerRpcInstances[ServerRpc]]
 ) extends ServerRpcCompanion[DefaultUdashSerialization, ServerRpc](DefaultUdashSerialization)
@@ -36,3 +54,7 @@ abstract class DefaultServerRpcCompanion[ServerRpc](
 abstract class DefaultClientRpcCompanion[ClientRpc](
   implicit instances: MacroInstances[DefaultUdashSerialization, ClientRpcInstances[ClientRpc]]
 ) extends ClientRpcCompanion[DefaultUdashSerialization, ClientRpc](DefaultUdashSerialization)
+
+abstract class DefaultBiDirectionRpcCompanion[BiDirectionRpc](
+  implicit instances: MacroInstances[DefaultUdashSerialization, BiDirectionRpcInstances[BiDirectionRpc]]
+) extends BiDirectionRpcCompanion[DefaultUdashSerialization, BiDirectionRpc](DefaultUdashSerialization)


### PR DESCRIPTION
Here a simple idea to introduce the 3rd type of RPC call: bi-diretion.

This RPC can be used as Client and as Server.