### PR TITLE
Introduced `AsyncAuthRequires`

### DIFF
--- a/auth/src/main/scala/io/udash/auth/AsyncAuthRequires.scala
+++ b/auth/src/main/scala/io/udash/auth/AsyncAuthRequires.scala
@@ -1,0 +1,19 @@
+package io.udash.auth
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait AsyncAuthRequires {
+  /** Checks if user context will have required permissions. */
+  def require(permission: PermissionCombinator, requireAuthenticated: Boolean = false)(implicit asyncUserCtx: Future[UserCtx], ec: ExecutionContext): Future[Unit] =
+    asyncUserCtx map { implicit ctx =>
+      AuthRequires.require(permission, requireAuthenticated)
+    }
+
+  /** Checks if user will be authenticated. */
+  def requireAuthenticated()(implicit futureUserCtx: Future[UserCtx], ec: ExecutionContext): Future[Unit] =
+    futureUserCtx map { implicit ctx =>
+      AuthRequires.requireAuthenticated()
+    }
+}
+
+object AsyncAuthRequires extends AsyncAuthRequires

--- a/auth/src/test/scala/io/udash/auth/AsyncAuthRequiresTest.scala
+++ b/auth/src/test/scala/io/udash/auth/AsyncAuthRequiresTest.scala
@@ -1,0 +1,36 @@
+package io.udash.auth
+
+import io.udash.testing.AsyncUdashSharedTest
+import org.scalatest.Succeeded
+
+import scala.concurrent.Future
+
+class AsyncAuthRequiresTest extends AsyncUdashSharedTest with AuthTestUtils {
+  import PermissionCombinator.AllowAll
+
+  "AsyncAuthRequiresTest utils" should {
+    "check user's permissions" in {
+      implicit val user: Future[UserCtx] = Future.successful(User(Set(P1, P2)))
+
+      for {
+        _ <- AsyncAuthRequires.require(P1.and(P2))
+        _ <- recoverToSucceededIf[UnauthorizedException] { AsyncAuthRequires.require(P1.and(P3)) }
+        _ <- recoverToSucceededIf[UnauthorizedException] { AsyncAuthRequires.require(P2.and(P3)) }
+        _ <- AsyncAuthRequires.require(P1.or(P3))
+        _ <- AsyncAuthRequires.require(AllowAll)
+      } yield Succeeded
+    }
+
+    "check is user is authenticated" in {
+      implicit val user: Future[UserCtx] = Future.successful(UnauthenticatedUser)
+      
+      for {
+        _ <- AsyncAuthRequires.require(AllowAll)
+        _ <- recoverToSucceededIf[UnauthenticatedException] {AsyncAuthRequires.require (AllowAll, requireAuthenticated = true)}
+        _ <- recoverToSucceededIf[UnauthenticatedException] {AsyncAuthRequires.requireAuthenticated()}
+        _ <- recoverToSucceededIf[UnauthenticatedException] {AsyncAuthRequires.require (P2.and (P3), requireAuthenticated = true)}
+        _ <- recoverToSucceededIf[UnauthorizedException] {AsyncAuthRequires.require (P2.and (P3))}
+      } yield Succeeded
+    }
+  }
+}


### PR DESCRIPTION
This is simple wrapper around `AuthRequires` which works fine with `Future[UserContext]`. Such future is standard behaviour for DB-layer which is based on slick.