### PR TITLE
Get rid of $ from generated ComponentId

### DIFF
--- a/macros/src/main/scala/io/udash/macros/ComponentIdMacro.scala
+++ b/macros/src/main/scala/io/udash/macros/ComponentIdMacro.scala
@@ -10,7 +10,7 @@ class ComponentIdMacro(val c: blackbox.Context) {
   final def IdObj: Tree = q"io.udash.component.ComponentId"
 
   def impl(): c.Tree = {
-    val fqn = Iterator.iterate(c.internal.enclosingOwner)(_.owner).find(_.isClass).get.fullName.replace('.', '-').replace('$', '__')
+    val fqn = Iterator.iterate(c.internal.enclosingOwner)(_.owner).find(_.isClass).get.fullName.replace('.', '-').replace('$', "__")
     q"$IdObj.forName($fqn)"
   }
 }

--- a/macros/src/main/scala/io/udash/macros/ComponentIdMacro.scala
+++ b/macros/src/main/scala/io/udash/macros/ComponentIdMacro.scala
@@ -10,7 +10,7 @@ class ComponentIdMacro(val c: blackbox.Context) {
   final def IdObj: Tree = q"io.udash.component.ComponentId"
 
   def impl(): c.Tree = {
-    val fqn = Iterator.iterate(c.internal.enclosingOwner)(_.owner).find(_.isClass).get.fullName.replace('.', '-')
+    val fqn = Iterator.iterate(c.internal.enclosingOwner)(_.owner).find(_.isClass).get.fullName.replace('.', '-').replace('$', '__')
     q"$IdObj.forName($fqn)"
   }
 }

--- a/macros/src/main/scala/io/udash/macros/ComponentIdMacro.scala
+++ b/macros/src/main/scala/io/udash/macros/ComponentIdMacro.scala
@@ -10,7 +10,7 @@ class ComponentIdMacro(val c: blackbox.Context) {
   final def IdObj: Tree = q"io.udash.component.ComponentId"
 
   def impl(): c.Tree = {
-    val fqn = Iterator.iterate(c.internal.enclosingOwner)(_.owner).find(_.isClass).get.fullName.replace('.', '-').replace('$', "__")
+    val fqn = Iterator.iterate(c.internal.enclosingOwner)(_.owner).find(_.isClass).get.fullName.replace('.', '-').replace("$", "__")
     q"$IdObj.forName($fqn)"
   }
 }


### PR DESCRIPTION
jQuery doesn't like `$`s in selectors. Probably jQuery wrapper could also replace `$` in selectors with `\\$`, however, it seems like a good idea to generate ids without `$`s. 

![image](https://user-images.githubusercontent.com/817407/159774494-8029c07f-fa83-4908-84a4-5bb375235e6f.png)

![image](https://user-images.githubusercontent.com/817407/159774562-7a63a8de-b423-4c9e-a973-655abb1d2358.png)
