### PR TITLE
STTP update - default backend for REST client change

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -362,6 +362,7 @@ lazy val benchmarks = jsProject(project)
     crossScalaVersions := Seq(Dependencies.versionOfScala),
     libraryDependencies ++= Dependencies.benchmarksSjsDeps.value,
     Compile / scalaJSUseMainModuleInitializer := true,
+    evictionErrorLevel := Level.Warn, //todo: remove after upickle 2.0.1+ is available
   )
 
 // Custom SBT tasks

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,7 @@ object Dependencies {
   val circeDerivationVersion = "0.13.0-M5" // Tests only
   val monixVersion = "3.4.1" // Tests only
 
-  val sttpVersion = "3.8.0"
+  val sttpVersion = "3.8.3"
 
   val scalaLoggingVersion = "3.9.5"
 
@@ -111,8 +111,6 @@ object Dependencies {
   ))
 
   val restJvmDeps = Def.setting(restCrossDeps.value ++ Seq(
-    "com.softwaremill.sttp.client3" %% "async-http-client-backend-future" % sttpVersion,
-    "com.softwaremill.sttp.client3" %% "async-http-client-backend-monix" % sttpVersion,
     "javax.servlet" % "javax.servlet-api" % servletVersion,
     "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingVersion,
     "org.eclipse.jetty" % "jetty-server" % jettyVersion % Test,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
 # suppress inspection "UnusedProperty"
-sbt.version=1.7.2
+sbt.version=1.8.0

--- a/rest/.jvm/src/main/scala/io/udash/rest/DefaultSttpBackend.scala
+++ b/rest/.jvm/src/main/scala/io/udash/rest/DefaultSttpBackend.scala
@@ -1,11 +1,10 @@
 package io.udash
 package rest
 
-import sttp.client3.SttpBackend
-import sttp.client3.asynchttpclient.future.AsyncHttpClientFutureBackend
+import sttp.client3.{HttpClientFutureBackend, SttpBackend}
 
 import scala.concurrent.Future
 
 object DefaultSttpBackend {
-  def apply(): SttpBackend[Future, Any] = AsyncHttpClientFutureBackend()
+  def apply(): SttpBackend[Future, Any] = HttpClientFutureBackend()
 }


### PR DESCRIPTION
Since `AsyncHttpClientFutureBackend` is now deprecated, I've removed the dependency and opted for a simpler default from JDK standard lib.