### PR TITLE
Existing RestSchema for sealed hierarchy improvement

### DIFF
--- a/rest/src/main/scala/io/udash/rest/openapi/RestSchema.scala
+++ b/rest/src/main/scala/io/udash/rest/openapi/RestSchema.scala
@@ -332,11 +332,6 @@ object InliningResolver {
     new InliningResolver().resolve(schema)
 }
 
-object ShallowInliningResolver extends SchemaResolver {
-  def resolve(schema: RestSchema[_]): RefOr[Schema] =
-    schema.name.fold(schema.createSchema(this))(RefOr.ref)
-}
-
 /**
  * An implementation of [[SchemaResolver]] which registers named [[RestSchema]]s and replaces them with a
  * [[https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#referenceObject Reference Object]].

--- a/rest/src/main/scala/io/udash/rest/openapi/RestSchema.scala
+++ b/rest/src/main/scala/io/udash/rest/openapi/RestSchema.scala
@@ -332,6 +332,11 @@ object InliningResolver {
     new InliningResolver().resolve(schema)
 }
 
+object ShallowInliningResolver extends SchemaResolver {
+  def resolve(schema: RestSchema[_]): RefOr[Schema] =
+    schema.name.fold(schema.createSchema(this))(RefOr.ref)
+}
+
 /**
  * An implementation of [[SchemaResolver]] which registers named [[RestSchema]]s and replaces them with a
  * [[https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#referenceObject Reference Object]].


### PR DESCRIPTION
The goal is to better handle case when existing RestSchema already contains right discriminator field when resolving RestSchema for sealed hierarchy case and allow it to retain custom name (see example in test code).