### PR TITLE
Possibility to define OpenAPI tags description using annotations

### DIFF
--- a/rest/.jvm/src/test/resources/RestTestApi.json
+++ b/rest/.jvm/src/test/resources/RestTestApi.json
@@ -267,6 +267,56 @@
         }
       }
     },
+    "/groupPrefix/subget/{p1}": {
+      "get": {
+        "tags": [
+          "GroupPrefix"
+        ],
+        "operationId": "groupPrefix_subget",
+        "parameters": [
+          {
+            "name": "p1",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "X-H1",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "q1",
+            "in": "query",
+            "required": true,
+            "explode": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/jsonFailingGet": {
       "get": {
         "operationId": "jsonFailingGet",
@@ -955,6 +1005,9 @@
     {
       "name": "Prefix",
       "description": "example API subgroup"
+    },
+    {
+      "name": "GroupPrefix"
     },
     {
       "name": "TrivialGroup"

--- a/rest/.jvm/src/test/resources/RestTestApi.json
+++ b/rest/.jvm/src/test/resources/RestTestApi.json
@@ -177,6 +177,9 @@
     },
     "/failingGet": {
       "get": {
+        "tags": [
+          "TrivialDescribedGroup"
+        ],
         "operationId": "failingGet",
         "responses": {
           "204": {
@@ -495,6 +498,9 @@
     "/prefix/{p0}/subget/{p1}": {
       "summary": "summary for prefix paths",
       "get": {
+        "tags": [
+          "Prefix"
+        ],
         "operationId": "prefix_subget",
         "parameters": [
           {
@@ -642,6 +648,9 @@
     },
     "/trivialGet": {
       "get": {
+        "tags": [
+          "TrivialGroup"
+        ],
         "operationId": "trivialGet",
         "responses": {
           "204": {
@@ -941,5 +950,18 @@
         ]
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Prefix",
+      "description": "example API subgroup"
+    },
+    {
+      "name": "TrivialGroup"
+    },
+    {
+      "name": "TrivialDescribedGroup",
+      "description": "something"
+    }
+  ]
 }

--- a/rest/src/test/scala/io/udash/rest/RestTestApi.scala
+++ b/rest/src/test/scala/io/udash/rest/RestTestApi.scala
@@ -75,8 +75,8 @@ case class ErrorWrapper[T](error: T)
 object ErrorWrapper extends HasPolyGenCodec[ErrorWrapper]
 
 trait RestTestApi {
-  @GET def trivialGet: Future[Unit]
-  @GET def failingGet: Future[Unit]
+  @GET @group("TrivialGroup") def trivialGet: Future[Unit]
+  @GET @group("TrivialDescribedGroup") @tagDescription("something") def failingGet: Future[Unit]
   @GET def jsonFailingGet: Future[Unit]
   @GET def moreFailingGet: Future[Unit]
   @GET def neverGet: Future[Unit]
@@ -124,6 +124,7 @@ trait RestTestApi {
   ): Future[String]
 
   @pathSummary("summary for prefix paths")
+  @describedGroup("example API subgroup")
   def prefix(
     p0: String,
     @Header("X-H0") h0: String,

--- a/rest/src/test/scala/io/udash/rest/RestTestApi.scala
+++ b/rest/src/test/scala/io/udash/rest/RestTestApi.scala
@@ -131,6 +131,9 @@ trait RestTestApi {
     @Query @example("q0example") q0: String
   ): RestTestSubApi
 
+  @group
+  def groupPrefix: RestTestSubApi
+
   @Prefix("") def transparentPrefix: RestTestSubApi
 
   def complexParams(
@@ -172,6 +175,7 @@ object RestTestApi extends DefaultRestApiCompanion[RestTestApi] {
       Future.successful(s"$q1-$p1-$p2")
     def prefix(p0: String, h0: String, q0: String): RestTestSubApi =
       RestTestSubApi.impl(s"$p0-$h0-$q0")
+    def groupPrefix: RestTestSubApi = RestTestSubApi.impl("")
     def transparentPrefix: RestTestSubApi = RestTestSubApi.impl("")
     def complexParams(baseEntity: BaseEntity, flatBaseEntity: Opt[FlatBaseEntity]): Future[Unit] = Future.unit
     def complexParams(flatBaseEntity: FlatBaseEntity, baseEntity: Opt[BaseEntity]): Future[Unit] = Future.unit


### PR DESCRIPTION
Add a possibility to define OpenAPI tags with descriptions using annotations in the REST framework