### PR TITLE
Add @schemaName annotation to customize RestSchema

### DIFF
--- a/rest/src/test/scala/io/udash/rest/openapi/RestSchemaTest.scala
+++ b/rest/src/test/scala/io/udash/rest/openapi/RestSchemaTest.scala
@@ -71,6 +71,22 @@ object FullyQualifiedHierarchy extends RestDataCompanionWithDeps[FullyQualifiedN
   case object Baz extends FullyQualifiedHierarchy
 }
 
+@flatten("case")
+sealed trait CustomSchemaNameHierarchy
+object CustomSchemaNameHierarchy extends RestDataCompanion[CustomSchemaNameHierarchy] {
+  // annotation value should be used as schema name, but NOT as discriminator value
+  @schemaName("CustomSchemaName123")
+  case class CustomSchemaName(str: String) extends CustomSchemaNameHierarchy
+
+  // annotation value should be used both as schema name and discriminator value
+  @name("CustomName123")
+  case class CustomName(str: String) extends CustomSchemaNameHierarchy
+
+  // @schemaName should "win" with @name as schema name
+  @schemaName("CustomSchemaNameBoth123") @name("CustomNameBoth123")
+  case class CustomNameBoth(str: String) extends CustomSchemaNameHierarchy
+}
+
 class RestSchemaTest extends AnyFunSuite {
   private def schemaStr[T](implicit schema: RestSchema[T]): String =
     printSchema(new InliningResolver().resolve(schema))
@@ -329,6 +345,88 @@ class RestSchemaTest extends AnyFunSuite {
         |        "$ref": "#/testSchemas/io.udash.rest.openapi.FullyQualifiedHierarchy.Bar"
         |      }
         |    ]
+        |  }
+        |}""".stripMargin)
+  }
+
+  test("Customized schema name") {
+    assert(allSchemasStr[CustomSchemaNameHierarchy] ==
+      """{
+        |  "CustomName123": {
+        |    "type": "object",
+        |    "properties": {
+        |      "case": {
+        |        "type": "string",
+        |        "enum": [
+        |          "CustomName123"
+        |        ]
+        |      },
+        |      "str": {
+        |        "type": "string"
+        |      }
+        |    },
+        |    "required": [
+        |      "case",
+        |      "str"
+        |    ]
+        |  },
+        |  "CustomSchemaName123": {
+        |    "type": "object",
+        |    "properties": {
+        |      "case": {
+        |        "type": "string",
+        |        "enum": [
+        |          "CustomSchemaName"
+        |        ]
+        |      },
+        |      "str": {
+        |        "type": "string"
+        |      }
+        |    },
+        |    "required": [
+        |      "case",
+        |      "str"
+        |    ]
+        |  },
+        |  "CustomSchemaNameBoth123": {
+        |    "type": "object",
+        |    "properties": {
+        |      "case": {
+        |        "type": "string",
+        |        "enum": [
+        |          "CustomNameBoth123"
+        |        ]
+        |      },
+        |      "str": {
+        |        "type": "string"
+        |      }
+        |    },
+        |    "required": [
+        |      "case",
+        |      "str"
+        |    ]
+        |  },
+        |  "CustomSchemaNameHierarchy": {
+        |    "type": "object",
+        |    "oneOf": [
+        |      {
+        |        "$ref": "#/testSchemas/CustomSchemaName123"
+        |      },
+        |      {
+        |        "$ref": "#/testSchemas/CustomName123"
+        |      },
+        |      {
+        |        "$ref": "#/testSchemas/CustomSchemaNameBoth123"
+        |      }
+        |    ],
+        |    "discriminator": {
+        |      "propertyName": "case",
+        |      "mapping": {
+        |        "CustomSchemaName": "#/testSchemas/CustomSchemaName123",
+        |        "CustomName123": "#/testSchemas/CustomName123",
+        |        "CustomNameBoth123": "#/testSchemas/CustomSchemaNameBoth123"
+        |      }
+        |    }
         |  }
         |}""".stripMargin)
   }


### PR DESCRIPTION
Add @schemaName annotation as a convenient way to customize RestSchema name, unlike com.avsystem.commons.serialization.name does NOT change serialized representation and type discriminator value when the class is a part of a sealed hierarchy.