### PR TITLE
Add NestedHierarchy schema and tests

### DIFF
--- a/rest/.jvm/src/test/resources/RestTestApi.json
+++ b/rest/.jvm/src/test/resources/RestTestApi.json
@@ -805,17 +805,20 @@
         "oneOf": [
           {
             "type": "object",
+            "title": "RestEntity",
             "properties": {
               "RestEntity": {
                 "$ref": "#/components/schemas/RestEntity"
               }
             },
+            "additionalProperties": false,
             "required": [
               "RestEntity"
             ]
           },
           {
             "type": "object",
+            "title": "RestOtherEntity",
             "properties": {
               "RestOtherEntity": {
                 "type": "object",
@@ -830,23 +833,28 @@
                     }
                   }
                 },
+                "additionalProperties": false,
                 "required": [
                   "fuu",
                   "kek"
                 ]
               }
             },
+            "additionalProperties": false,
             "required": [
               "RestOtherEntity"
             ]
           },
           {
             "type": "object",
+            "title": "SingletonEntity",
             "properties": {
               "SingletonEntity": {
-                "type": "object"
+                "type": "object",
+                "additionalProperties": false
               }
             },
+            "additionalProperties": false,
             "required": [
               "SingletonEntity"
             ]

--- a/rest/src/main/scala/io/udash/rest/openapi/RestStructure.scala
+++ b/rest/src/main/scala/io/udash/rest/openapi/RestStructure.scala
@@ -42,8 +42,9 @@ object RestStructure extends AdtMetadataCompanion[RestStructure] {
         if (caseFieldOpt.nonEmpty) baseSchema
         else {
           val adjustedBase = baseSchema match {
-            case RefOr.Value(s) => RefOr(s.copy(additionalProperties = AdditionalProperties.Flag(value = false)))
-            case ref => ref
+            case RefOr.Value(s) if s.`type`.contains(DataType.Object) && s.additionalProperties == AdditionalProperties.Flag(value = true) =>
+              RefOr(s.copy(additionalProperties = AdditionalProperties.Flag(value = false)))
+            case other => other
           }
           RefOr(Schema(
             `type` = DataType.Object,

--- a/rest/src/main/scala/io/udash/rest/openapi/RestStructure.scala
+++ b/rest/src/main/scala/io/udash/rest/openapi/RestStructure.scala
@@ -40,11 +40,19 @@ object RestStructure extends AdtMetadataCompanion[RestStructure] {
       val caseSchemas = cases.map { c =>
         val baseSchema = resolver.resolve(c.caseSchema(caseFieldOpt))
         if (caseFieldOpt.nonEmpty) baseSchema
-        else RefOr(Schema(
-          `type` = DataType.Object,
-          properties = IListMap(c.info.rawName -> baseSchema),
-          required = List(c.info.rawName)
-        ))
+        else {
+          val adjustedBase = baseSchema match {
+            case RefOr.Value(s) => RefOr(s.copy(additionalProperties = AdditionalProperties.Flag(value = false)))
+            case ref => ref
+          }
+          RefOr(Schema(
+            `type` = DataType.Object,
+            title = c.info.rawName,
+            properties = IListMap(c.info.rawName -> adjustedBase),
+            additionalProperties = AdditionalProperties.Flag(value = false),
+            required = List(c.info.rawName)
+          ))
+        }
       }
       val disc = caseFieldOpt.map { caseFieldName =>
         val mapping = IListMap((cases zip caseSchemas).collect {

--- a/rest/src/main/scala/io/udash/rest/openapi/RestStructure.scala
+++ b/rest/src/main/scala/io/udash/rest/openapi/RestStructure.scala
@@ -51,7 +51,7 @@ object RestStructure extends AdtMetadataCompanion[RestStructure] {
             title = c.info.rawName,
             properties = IListMap(c.info.rawName -> adjustedBase),
             additionalProperties = AdditionalProperties.Flag(value = false),
-            required = List(c.info.rawName)
+            required = List(c.info.rawName),
           ))
         }
       }

--- a/rest/src/test/scala/io/udash/rest/openapi/RestSchemaTest.scala
+++ b/rest/src/test/scala/io/udash/rest/openapi/RestSchemaTest.scala
@@ -63,6 +63,12 @@ object HierarchyRoot {
     RestStructure.materialize[HierarchyRoot[String]].standaloneSchema.named("StringHierarchy")
 }
 
+sealed trait NestedHierarchy
+final case class NestedHierarchyCase(value: String) extends NestedHierarchy
+final case class NestedHierarchyCase2(value: Int) extends NestedHierarchy
+
+object NestedHierarchy extends RestDataCompanion[NestedHierarchy]
+
 @flatten("case") sealed trait FullyQualifiedHierarchy
 object FullyQualifiedHierarchy extends RestDataCompanionWithDeps[FullyQualifiedNames.type, FullyQualifiedHierarchy] {
   final case class Foo(str: String) extends FullyQualifiedHierarchy
@@ -347,6 +353,63 @@ class RestSchemaTest extends AnyFunSuite {
         |    ]
         |  }
         |}""".stripMargin)
+  }
+
+  test("Nested hierarchy") {
+    assert(allSchemasStr[NestedHierarchy] ==
+      """{
+        |  "NestedHierarchy": {
+        |    "type": "object",
+        |    "oneOf": [
+        |      {
+        |        "type": "object",
+        |        "title": "NestedHierarchyCase",
+        |        "properties": {
+        |          "NestedHierarchyCase": {
+        |            "type": "object",
+        |            "properties": {
+        |              "value": {
+        |                "type": "string"
+        |              }
+        |            },
+        |            "additionalProperties": false,
+        |            "required": [
+        |              "value"
+        |            ]
+        |          }
+        |        },
+        |        "additionalProperties": false,
+        |        "required": [
+        |          "NestedHierarchyCase"
+        |        ]
+        |      },
+        |      {
+        |        "type": "object",
+        |        "title": "NestedHierarchyCase2",
+        |        "properties": {
+        |          "NestedHierarchyCase2": {
+        |            "type": "object",
+        |            "properties": {
+        |              "value": {
+        |                "type": "integer",
+        |                "format": "int32"
+        |              }
+        |            },
+        |            "additionalProperties": false,
+        |            "required": [
+        |              "value"
+        |            ]
+        |          }
+        |        },
+        |        "additionalProperties": false,
+        |        "required": [
+        |          "NestedHierarchyCase2"
+        |        ]
+        |      }
+        |    ]
+        |  }
+        |}""".stripMargin
+    )
   }
 
   test("Customized schema name") {

--- a/rest/src/test/scala/io/udash/rest/openapi/RestSchemaTest.scala
+++ b/rest/src/test/scala/io/udash/rest/openapi/RestSchemaTest.scala
@@ -69,6 +69,12 @@ final case class NestedHierarchyCase2(value: Int) extends NestedHierarchy
 
 object NestedHierarchy extends RestDataCompanion[NestedHierarchy]
 
+sealed trait NestedHierarchyWithEdgeCases
+@transparent final case class TransparentCase(value: String) extends NestedHierarchyWithEdgeCases
+final case class MapCase(entries: Map[String, Int]) extends NestedHierarchyWithEdgeCases
+
+object NestedHierarchyWithEdgeCases extends RestDataCompanion[NestedHierarchyWithEdgeCases]
+
 @flatten("case") sealed trait FullyQualifiedHierarchy
 object FullyQualifiedHierarchy extends RestDataCompanionWithDeps[FullyQualifiedNames.type, FullyQualifiedHierarchy] {
   final case class Foo(str: String) extends FullyQualifiedHierarchy
@@ -404,6 +410,57 @@ class RestSchemaTest extends AnyFunSuite {
         |        "additionalProperties": false,
         |        "required": [
         |          "NestedHierarchyCase2"
+        |        ]
+        |      }
+        |    ]
+        |  }
+        |}""".stripMargin
+    )
+  }
+
+  test("Nested hierarchy with transparent and map cases") {
+    assert(allSchemasStr[NestedHierarchyWithEdgeCases] ==
+      """{
+        |  "NestedHierarchyWithEdgeCases": {
+        |    "type": "object",
+        |    "oneOf": [
+        |      {
+        |        "type": "object",
+        |        "title": "TransparentCase",
+        |        "properties": {
+        |          "TransparentCase": {
+        |            "type": "string"
+        |          }
+        |        },
+        |        "additionalProperties": false,
+        |        "required": [
+        |          "TransparentCase"
+        |        ]
+        |      },
+        |      {
+        |        "type": "object",
+        |        "title": "MapCase",
+        |        "properties": {
+        |          "MapCase": {
+        |            "type": "object",
+        |            "properties": {
+        |              "entries": {
+        |                "type": "object",
+        |                "additionalProperties": {
+        |                  "type": "integer",
+        |                  "format": "int32"
+        |                }
+        |              }
+        |            },
+        |            "additionalProperties": false,
+        |            "required": [
+        |              "entries"
+        |            ]
+        |          }
+        |        },
+        |        "additionalProperties": false,
+        |        "required": [
+        |          "MapCase"
         |        ]
         |      }
         |    ]


### PR DESCRIPTION
 Non-flat (nested) sealed hierarchy schemas does not have discriminator and should be encoded in open-api spec on its own way.