### PR TITLE
Update Scala Steward pins: drop logback, add Atmosphere

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -2,7 +2,9 @@ updates.ignore = [
   {groupId = "com.vladsch.flexmark", artifactId = "flexmark-all"},
 ]
 updates.pin = [
-  {groupId = "ch.qos.logback", version = "1.3."},
+  # Pin until Udash migrates to jakarta.servlet + Jetty ee10.
+  # Atmosphere 3.x switched to jakarta.servlet; 4.x also requires Java 21.
+  {groupId = "org.atmosphere", artifactId = "atmosphere-runtime", version = "2.7."},
 ]
 pullRequests.grouping = [
   {


### PR DESCRIPTION
## Summary
- Drop the `ch.qos.logback` 1.3.x pin. Empirically unnecessary: every AVS repo already runs logback 1.5.x on the same javax/Jetty-ee8 stack without issue. `logback-classic`'s `jakarta.servlet-api` is `provided` scope and is only relevant if `LogbackServletContainerInitializer` is wired in, which Udash does not do.
- Add a pin for `org.atmosphere:atmosphere-runtime` on the 2.7 line. Atmosphere 3.x switched to `jakarta.servlet` (jakarta.servlet-api 5.0+) and 4.x additionally requires Java 21. Udash is on `javax.servlet-api` 4.0.1 with `jetty-ee8-*` modules, and `org.atmosphere.cpr.*` types appear on Udash's compile-time API (`AtmosphereService.scala`, `DefaultAtmosphereServiceConfig.scala`, etc.). Bumping would require migrating Udash's whole servlet stack to jakarta and raising the Java baseline. Both pins should be lifted together when Udash migrates to jakarta + Jetty ee10. Closes the recurring Steward bump (#1496).

## Test plan
- [ ] CI green on the conf change (no code touched)